### PR TITLE
Billing country always "NL"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
   ],
   "require": {
     "shopware/core": "*",
-    "mollie/mollie-api-php": "^2.0"
+    "mollie/mollie-api-php": "^2.0",
+    "ext-mbstring": "*"
   },
   "extra": {
     "shopware-plugin-class": "Kiener\\MolliePayments\\MolliePayments",

--- a/src/Service/CustomerService.php
+++ b/src/Service/CustomerService.php
@@ -71,10 +71,12 @@ class CustomerService
         try {
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('id', $customerId));
-            $criteria->addAssociation('activeShippingAddress');
-            $criteria->addAssociation('activeBillingAddress');
-            $criteria->addAssociation('defaultShippingAddress');
-            $criteria->addAssociation('defaultBillingAddress');
+            $criteria->addAssociations([
+                'activeShippingAddress.country',
+                'activeBillingAddress.country',
+                'defaultShippingAddress.country',
+                'defaultBillingAddress.country',
+            ]);
 
             /** @var CustomerEntity $customer */
             $customer = $this->customerRepository->search($criteria, $context)->first();

--- a/src/Service/LoggerService.php
+++ b/src/Service/LoggerService.php
@@ -51,7 +51,8 @@ class LoggerService
 
         // Add data to the log entry
         $logEntry = [
-            self::LOG_ENTRY_KEY_MESSAGE => $message,
+            // The `message` column is limited to 255 chars
+            self::LOG_ENTRY_KEY_MESSAGE => mb_substr($message, 0, 254),
             self::LOG_ENTRY_KEY_LEVEL => $level,
             self::LOG_ENTRY_KEY_CHANNEL => self::LOG_ENTRY_CHANNEL,
             self::LOG_ENTRY_KEY_CONTEXT => [


### PR DESCRIPTION
When testing the Klarna Slice It. payment, I discovered that the Mollie API responded with: "The billing country is not supported for the payment method".

I was using a German address, that payment should be possible there. During debugging I realized the plugin send "NL" as the billing country, coming from the default fallback when no country was provided.

The country wasn't available, because it's association wasn't loaded initially. The Shopware DAL only loads OneToOne associations by default, and this is also true for associations of associations (like the country in an address).

So this fix adds the relations for the country to all loaded addresses.
![image](https://user-images.githubusercontent.com/174161/82996883-ed9d2180-a005-11ea-8af0-51a1f13b2ebe.png)

And I also added a commit for the issue #23 that occured during debugging as a bonus :)