### PR TITLE
fixing UTC default

### DIFF
--- a/src/Setting/MollieSettingStruct.php
+++ b/src/Setting/MollieSettingStruct.php
@@ -230,7 +230,7 @@ class MollieSettingStruct extends Struct
     public function getOrderLifetimeDate(): string
     {
         return (new DateTime())
-            ->setTimezone(new DateTimeZone(DateTimeZone::UTC))
+            ->setTimezone(new DateTimeZone('UTC'))
             ->modify(sprintf('+%d day', $this->getOrderLifetimeDays()))
             ->format('Y-m-d');
     }


### PR DESCRIPTION
DateTimeZone::UTC is not valid and can throw an error: DateTimeZone::__construct(): Unknown or bad timezone (1024)

more info:
https://stackoverflow.com/questions/34839218/php-strange-contants-in-datetimezone-class