### PR TITLE
MOL-140: fix failed transactions redirect if standard shopware handling is active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /vendor
+.DS_Store


### PR DESCRIPTION
we have to return the failed status even if transition has failed before. Method is called more than one time during payment process