### PR TITLE
FIX: ContextPersister requires saleschannelId in 6.3.4

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -59,6 +59,7 @@
             <argument type="service" id="monolog.logger"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
             <argument type="service" id="salutation.repository" />
+            <argument>%kernel.shopware_version%</argument>
         </service>
 
         <service id="Kiener\MolliePayments\Service\CustomFieldService" class="Kiener\MolliePayments\Service\CustomFieldService">

--- a/src/Service/CustomerService.php
+++ b/src/Service/CustomerService.php
@@ -100,7 +100,9 @@ class CustomerService
                 'customerId' => $customer->getId(),
                 'billingAddressId' => null,
                 'shippingAddressId' => null,
-            ]
+            ],
+            $context->getSalesChannel()->getId(),
+            $customer->getId()
         );
 
         /** @var CustomerLoginEvent $event */


### PR DESCRIPTION
This fixes an issue with Apple Pay Direct and the upcoming PayPal Shortcut in 6.3.5+