### PR TITLE
MOL-159: do not send lifetimedays if they are not set in config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.1/phpunit.xsd"
-         bootstrap="phpunit.autoload.php"
-         cacheResult="false">
-
-    <testsuites>
-        <testsuite name="MolliePayments Tests">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./</directory>
-        </whitelist>
-    </filter>
-
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="phpunit.autoload.php" cacheResult="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="MolliePayments Tests">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-         bootstrap="phpunit.autoload.php" cacheResult="false">
+         bootstrap="phpunit.autoload.php"
+         cacheResult="false"
+         colors="true"
+>
   <coverage>
     <include>
-      <directory suffix=".php">./src</directory>
+      <directory>./src</directory>
     </include>
   </coverage>
   <testsuites>
     <testsuite name="MolliePayments Tests">
-      <directory>tests/</directory>
+      <directory>./oder kotests</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
   </coverage>
   <testsuites>
     <testsuite name="MolliePayments Tests">
-      <directory>./oder kotests</directory>
+      <directory>./tests</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/src/Setting/MollieSettingStruct.php
+++ b/src/Setting/MollieSettingStruct.php
@@ -269,10 +269,14 @@ class MollieSettingStruct extends Struct
     }
 
     /**
-     * @return int
+     * @return ?int
      */
-    public function getOrderLifetimeDays(): int
+    public function getOrderLifetimeDays(): ?int
     {
+        if(!$this->orderLifetimeDays)
+        {
+            return null;
+        }
         return min(
             max(
                 self::ORDER_EXPIRES_AT_MIN_DAYS,
@@ -286,11 +290,16 @@ class MollieSettingStruct extends Struct
      * @return string
      * @throws Exception
      */
-    public function getOrderLifetimeDate(): string
+    public function getOrderLifetimeDate(): ?string
     {
+        $orderLifeTimeDays = $this->getOrderLifetimeDays();
+        if(!$orderLifeTimeDays)
+        {
+            return null;
+        }
         return (new DateTime())
             ->setTimezone(new DateTimeZone('UTC'))
-            ->modify(sprintf('+%d day', $this->getOrderLifetimeDays()))
+            ->modify(sprintf('+%d day', $orderLifeTimeDays))
             ->format('Y-m-d');
     }
 

--- a/tests/Setting/MollieSettingsStructTest.php
+++ b/tests/Setting/MollieSettingsStructTest.php
@@ -16,7 +16,6 @@ final class MollieSettingsStructTest extends TestCase
     /**
      * test to get a maximum range of order life time days
      *
-     * @author Vitalij Mik
      * @dataProvider orderLifeTimeDaysData
      * @param $lifeTimeDays
      * @param int|null $realLifeTimeDays
@@ -36,7 +35,6 @@ final class MollieSettingsStructTest extends TestCase
     /**
      * test get the correct calculation based on oderLifetimeDays config
      *
-     * @author Vitalij Mik
      * @dataProvider orderLifeTimeDaysData
      * @param $lifeTimeDays
      * @param int|null $realLifeTimeDays

--- a/tests/Setting/MollieSettingsStructTest.php
+++ b/tests/Setting/MollieSettingsStructTest.php
@@ -8,9 +8,7 @@ use DateTimeZone;
 use Kiener\MolliePayments\Setting\MollieSettingStruct;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @copyright 2021 dasistweb GmbH (https://www.dasistweb.de)
- */
+
 final class MollieSettingsStructTest extends TestCase
 {
 

--- a/tests/Setting/MollieSettingsStructTest.php
+++ b/tests/Setting/MollieSettingsStructTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+
+namespace Kiener\MolliePayments\Tests\Setting;
+
+use DateTime;
+use DateTimeZone;
+use Kiener\MolliePayments\Setting\MollieSettingStruct;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @copyright 2021 dasistweb GmbH (https://www.dasistweb.de)
+ */
+final class MollieSettingsStructTest extends TestCase
+{
+
+
+    /**
+     * test to get a maximum range of order life time days
+     *
+     * @author Vitalij Mik
+     * @dataProvider orderLifeTimeDaysData
+     * @param $lifeTimeDays
+     * @param int|null $realLifeTimeDays
+     */
+    public function testGetOrderLifetimeDays($lifeTimeDays,?int $realLifeTimeDays)
+    {
+        $settingsStruct = new MollieSettingStruct();
+
+        $settingsStruct->assign([
+           'orderLifetimeDays'=>$lifeTimeDays
+        ]);
+        $actualValue =$settingsStruct->getOrderLifetimeDays();
+        $this->assertSame($realLifeTimeDays,$actualValue);
+
+    }
+
+    /**
+     * test get the correct calculation based on oderLifetimeDays config
+     *
+     * @author Vitalij Mik
+     * @dataProvider orderLifeTimeDaysData
+     * @param $lifeTimeDays
+     * @param int|null $realLifeTimeDays
+     * @param string|null $expectedDateString
+     * @throws \Exception
+     */
+    public function testGetOrderLifetimeDate($lifeTimeDays,?int $realLifeTimeDays,?string $expectedDateString)
+    {
+        $settingsStruct = new MollieSettingStruct();
+
+        $settingsStruct->assign([
+            'orderLifetimeDays'=>$lifeTimeDays
+        ]);
+        $actualValue =$settingsStruct->getOrderLifetimeDate();
+        $this->assertSame($expectedDateString,$actualValue);
+    }
+
+
+    public function orderLifeTimeDaysData()
+    {
+        $today = (new DateTime())->setTimezone(new DateTimeZone('UTC'));
+
+        return [
+            'oderLifeTime cannot be smaller than minimum' => [-1,1,(clone $today)->modify('+1 day')->format('Y-m-d')],
+            'orderLifeTime cannot be bigger than maximum' => [1000,100,(clone $today)->modify('+100 day')->format('Y-m-d')],
+            'orderLifeTime can be set' => [10,10,(clone $today)->modify('+10 day')->format('Y-m-d')],
+            'orderLifeTime can be null' => [null,null,null],
+            'orderLifeTime can be empty' => ['',null,null],
+        ];
+    }
+
+}


### PR DESCRIPTION
made the methods getOrderLifetimeDays and getOrderLifetimeDate nullable.

in the File Handler/Method/PaymentHandler.php:578-582

there is following line
```php 
         $dueDate = $settings->getOrderLifetimeDate();

            if ($dueDate !== null) {
                $orderData[self::FIELD_EXPIRES_AT] = $dueDate;
            }
```
so i assume if the $dueDate is not set it will not send to the api request. if the date is not configured in the plugin settings, this method will return null

            
            