### PR TITLE
Fix LineItem not stackable error when a promotion is added to the cart

### DIFF
--- a/src/Service/CartService.php
+++ b/src/Service/CartService.php
@@ -99,6 +99,8 @@ class CartService
             1
         );
 
+        $lineItem->setStackable(true);
+
         return $this->salesChannelCartService->add($cart, $lineItem, $newSalesChannelContext);
     }
 }


### PR DESCRIPTION
@schmitzcarsten This PR is in response to the issue you raised in your email.

When creating a LineItem, as is being done in CartService on line 95, stackable is set to false by default. When a promotion is added to the cart, either manually through a coupon or automatically, Shopware tries to calculate the discount by cloning the lineitem according to the quantity (So if quantity is 3 it will create 3 clones of the lineitem) and setting the quantity to 1 on each clone. However, setting the quantity is not possible when stackable is set to false, thus generating the "LineItem is not stackable" error.

Fix is to just set the lineitem to be stackable. 

Note that since the lineitem is created in the cartservice, this should also affect Apple Pay Direct, which uses the same function to add the selected product to the new cart.