### PR TITLE
MOL-365: Correct API Exception Handling to reallow Redirect to Finish

### DIFF
--- a/src/Exception/PaymentUrlException.php
+++ b/src/Exception/PaymentUrlException.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Kiener\MolliePayments\Exception;
+
+
+use Shopware\Core\Checkout\Payment\Exception\PaymentProcessException;
+
+/**
+ * @copyright 2021 dasistweb GmbH (https://www.dasistweb.de)
+ */
+class PaymentUrlException extends PaymentProcessException
+{
+
+
+    public function getErrorCode(): string
+    {
+        return (string) parent::getCode();
+    }
+}


### PR DESCRIPTION
When an API Exception occured the pay method of PaymentHandler did throw a RuntimeException. This Exception Type isn't handled in the Shopware CheckoutController order action and this caused:
- the redirect to finish page didn't work anymore
- the customer did see a page at the checkout/order route which isn't meant to show a frontend page and so it's mostly unstyled

Solution:
Created a new Exception type which is a subclass of PaymentProcessException and so handled by the Shopware CheckoutController order action. Now in case of an API Exception the customer is redirected to checkout/finish and from there to account/order to change the payment method:
![image](https://user-images.githubusercontent.com/40621547/112990921-e0414e00-9166-11eb-9d6c-ba49d9e2c9fd.png)
