### PR TITLE
MOL-377: Fix wrong API key of specific channel in components

### DIFF
--- a/src/Factory/MollieApiFactory.php
+++ b/src/Factory/MollieApiFactory.php
@@ -48,17 +48,17 @@ class MollieApiFactory
      */
     public function createClient(?string $salesChannelId = null): MollieApiClient
     {
-        if ($this->apiClient === null) {
-            $this->apiClient = $this->getClient($salesChannelId);
-        }
-
-        return $this->apiClient;
+        # TODO Refactor into getClient() below
+        # the singleton approach here was too risky,
+        # everyone who used this was never able to switch api keys through sales channels.
+        # now its the same as getClient() -> should be combined one day
+        return $this->getClient($salesChannelId);
     }
 
     /**
      * Returns a new instance of the Mollie API client.
      *
-     * @param string|null  $salesChannelId
+     * @param string|null $salesChannelId
      * @param Context|null $context
      *
      * @return MollieApiClient

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -217,7 +217,7 @@
         </service>
 
         <service id="Kiener\MolliePayments\Subscriber\CheckoutConfirmPageSubscriber" class="Kiener\MolliePayments\Subscriber\CheckoutConfirmPageSubscriber">
-            <argument type="service" id="Mollie\Api\MollieApiClient"/>
+            <argument type="service" id="Kiener\MolliePayments\Factory\MollieApiFactory"/>
             <argument type="service" id="Kiener\MolliePayments\Service\SettingsService"/>
             <argument type="service" id="language.repository"/>
             <argument type="service" id="locale.repository"/>


### PR DESCRIPTION
if you have a specific configuration (api key) of a single sales channel, then this configuration has not been used.
it was always the MollieApiClient for the configuration for "All Sales Channels"

the origin of the problem was the singleton approach in the factory, i dont know where its created the first time, but it was with the wrong api key

i've tested: 
* before: var_dump with api key in components subscriber showed api key A (all) even though "storefront" had B
* after: var_dump shows api key B if enabled

i've improved the class itself a bit


IMPORTANT!
this factory fix could fix more problems related to refudns and shipping (where it has been used).
but it can also show problems "suddenly" when a merchant has a custom configuration that is wrong...at the moment its actually working...but wrong anyway :)
