### PR TITLE
NTR: fix ci pipeline

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -183,6 +183,19 @@ jobs:
         run: |
           docker exec shop bash -c 'php bin/console plugin:refresh'
           docker exec shop bash -c 'php bin/console plugin:install MolliePayments --activate'
+
+      - name: Build artifacts
+        run: |
+          docker exec shop bash -c './bin/build-js.sh'
+          docker exec shop bash -c 'php bin/console theme:refresh'
+          docker exec shop bash -c 'php bin/console theme:compile'
+          docker exec shop bash -c 'php bin/console theme:refresh'
+
+      - name: Reinstall Plugin
+        run: |
+          docker exec shop bash -c 'php bin/console plugin:refresh'
+          docker exec shop bash -c 'php bin/console plugin:deactivate MolliePayments'
+          docker exec shop bash -c 'php bin/console plugin:activate MolliePayments'
           docker exec shop bash -c 'php bin/console system:config:set MolliePayments.config.liveApiKey ${{ secrets.MOLLIE_APIKEY_TEST }}'
           docker exec shop bash -c 'php bin/console system:config:set MolliePayments.config.testApiKey ${{ secrets.MOLLIE_APIKEY_TEST }}'
           docker exec shop bash -c 'php bin/console system:config:set MolliePayments.config.testMode true'


### PR DESCRIPTION
artefacts have been excluded by gitignore. We have to create them before integration and e2e tests