### PR TITLE
MOL-465: Hide Apple Pay if not possible

### DIFF
--- a/tests/Cypress/cypress/integration/6.4/storefront/payment-methods/applepay.spec.js
+++ b/tests/Cypress/cypress/integration/6.4/storefront/payment-methods/applepay.spec.js
@@ -1,0 +1,68 @@
+import Devices from "Services/Devices";
+import Session from "Actions/utils/Session"
+// ------------------------------------------------------
+import ShopConfigurationAction from "Actions/6.4/admin/ShopConfigurationAction";
+// ------------------------------------------------------
+import TopMenuAction from 'Actions/6.4/storefront/navigation/TopMenuAction';
+import LoginAction from 'Actions/6.4/storefront/account/LoginAction';
+import RegisterAction from 'Actions/6.4/storefront/account/RegisterAction';
+import ListingAction from 'Actions/6.4/storefront/products/ListingAction';
+import PDPAction from 'Actions/6.4/storefront/products/PDPAction';
+import CheckoutAction from 'Actions/6.4/storefront/checkout/CheckoutAction';
+
+
+const devices = new Devices();
+const session = new Session();
+
+const configAction = new ShopConfigurationAction();
+
+const topMenu = new TopMenuAction();
+const register = new RegisterAction();
+const login = new LoginAction();
+const listing = new ListingAction();
+const pdp = new PDPAction();
+const checkout = new CheckoutAction();
+
+const user_email = "dev@localhost.de";
+const user_pwd = "MollieMollie111";
+
+const device = devices.getFirstDevice();
+
+
+context("Apple Pay", () => {
+
+    before(function () {
+        devices.setDevice(device);
+        configAction.setupShop();
+        register.doRegister(user_email, user_pwd);
+    })
+
+    beforeEach(() => {
+        session.resetBrowserSession();
+        devices.setDevice(device);
+    });
+
+
+    it('Apple Pay hidden if not available in browser', () => {
+
+        cy.visit('/');
+
+        login.doLogin(user_email, user_pwd);
+
+        topMenu.clickOnHome();
+        listing.clickOnFirstProduct();
+        pdp.addToCart(1);
+
+        checkout.goToCheckoutInOffCanvas();
+
+        checkout.showAllPaymentMethods();
+
+        // wait a bit, because the client side
+        // code for the ApplePay recognition needs to
+        // be executed first
+        cy.wait(2000);
+
+        cy.contains('Apple Pay').should('not.exist');
+    })
+
+})

--- a/tests/Cypress/cypress/integration/old/storefront/payment-methods/applepay.spec.js
+++ b/tests/Cypress/cypress/integration/old/storefront/payment-methods/applepay.spec.js
@@ -1,0 +1,69 @@
+import Devices from "Services/Devices";
+import Session from "Actions/utils/Session"
+// ------------------------------------------------------
+import ShopConfigurationAction from "Actions/old/admin/ShopConfigurationAction";
+// ------------------------------------------------------
+import TopMenuAction from 'Actions/old/storefront/navigation/TopMenuAction';
+import LoginAction from 'Actions/old/storefront/account/LoginAction';
+import RegisterAction from 'Actions/old/storefront/account/RegisterAction';
+import ListingAction from 'Actions/old/storefront/products/ListingAction';
+import PDPAction from 'Actions/old/storefront/products/PDPAction';
+import CheckoutAction from 'Actions/old/storefront/checkout/CheckoutAction';
+
+
+const devices = new Devices();
+const session = new Session();
+
+const configAction = new ShopConfigurationAction();
+
+const topMenu = new TopMenuAction();
+const register = new RegisterAction();
+const login = new LoginAction();
+const listing = new ListingAction();
+const pdp = new PDPAction();
+const checkout = new CheckoutAction();
+
+
+const user_email = "dev@localhost.de";
+const user_pwd = "MollieMollie111";
+
+const device = devices.getFirstDevice();
+
+
+context("Apple Pay", () => {
+
+    before(function () {
+        devices.setDevice(device);
+        configAction.setupShop();
+        register.doRegister(user_email, user_pwd);
+    })
+
+    beforeEach(() => {
+        session.resetBrowserSession();
+        devices.setDevice(device);
+    });
+
+
+    it('Apple Pay hidden if not available in browser', () => {
+
+        cy.visit('/');
+
+        login.doLogin(user_email, user_pwd);
+
+        topMenu.clickOnHome();
+        listing.clickOnFirstProduct();
+        pdp.addToCart(1);
+
+        checkout.goToCheckoutInOffCanvas();
+
+        checkout.openPaymentSelectionOnConfirm();
+
+        // wait a bit, because the client side
+        // code for the ApplePay recognition needs to
+        // be executed first
+        cy.wait(2000);
+
+        cy.contains('Apple Pay').should('not.exist');
+    })
+
+})

--- a/tests/Cypress/cypress/support/actions/6.4/storefront/checkout/CheckoutAction.js
+++ b/tests/Cypress/cypress/support/actions/6.4/storefront/checkout/CheckoutAction.js
@@ -26,13 +26,20 @@ export default class CheckoutAction {
 
     /**
      *
+     */
+    showAllPaymentMethods() {
+        repoConfirm.getShowMorePaymentButtonsLabel().click();
+    }
+
+    /**
+     *
      * @param paymentName
      */
     switchPaymentMethod(paymentName) {
 
         // expand our collapsed view of payment methods
         // then we see the full list afterwards
-        repoConfirm.getShowMorePaymentButtonsLabel().click();
+        this.showAllPaymentMethods();
 
         // click on the name of the payment
         cy.contains(paymentName).click({force: true});

--- a/tests/Cypress/cypress/support/repositories/6.4/storefront/products/PDPRepository.js
+++ b/tests/Cypress/cypress/support/repositories/6.4/storefront/products/PDPRepository.js
@@ -13,7 +13,7 @@ export default class PDPRepository {
      * @returns {*}
      */
     getQuantity() {
-        return cy.get('.custom-select');
+        return cy.get('.col-4 > .custom-select');
     }
 
 }

--- a/tests/Cypress/cypress/support/repositories/old/storefront/products/PDPRepository.js
+++ b/tests/Cypress/cypress/support/repositories/old/storefront/products/PDPRepository.js
@@ -13,7 +13,7 @@ export default class PDPRepository {
      * @returns {*}
      */
     getQuantity() {
-        return cy.get('.custom-select');
+        return cy.get('.col-4 > .custom-select');
     }
 
 }


### PR DESCRIPTION
apple pay is now hidden again in the payment selection page

this works for both > and < shopware 6.4

i did also remove the payment method instead of hiding it,
had to do with cypress (temp. mind fuckup) but in the end isnt it better anyway?

+ 2 cypress tests