### PR TITLE
MOL-461: Fix iDEAL Issuers in Shopware 6.4

### DIFF
--- a/src/Resources/views/storefront/component/payment/payment-method.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-method.html.twig
@@ -1,6 +1,16 @@
 {# compatible with >= sw6.4 #}
 {% sw_extends '@Storefront/storefront/component/payment/payment-method.html.twig' %}
 
+{% block component_payment_method_input %}
+    <input type="radio"
+           id="paymentMethod{{ payment.id }}"
+           name="paymentMethodId"
+           value="{{ payment.id }}"
+           {% if payment.id is same as(selectedPaymentMethodId) %}checked="checked"{% endif %}
+           class="custom-control-input payment-method-input {{ payment.translated.customFields.mollie_payment_method_name }}">
+{% endblock %}
+
+
 {% block component_payment_method_description %}
     {{ parent() }}
 

--- a/tests/Cypress/cypress/integration/6.4/storefront/checkout/checkout-full.spec.js
+++ b/tests/Cypress/cypress/integration/6.4/storefront/checkout/checkout-full.spec.js
@@ -105,15 +105,6 @@ context("Checkout Tests", () => {
 
                     } else {
 
-                        // this was not necessary in shopware < 6.4
-                        // in 6.4 the built in issuer dropdown doesnt yet work
-                        // that's why an issuer list is displayed in mollie.
-                        // once repaired in Shopware, the "payment" screen should be
-                        // opened immediately
-                        if (payment.key === 'ideal') {
-                            mollieIssuer.selectIDEAL();
-                        }
-
                         if (payment.key === 'kbc') {
                             mollieIssuer.selectKBC();
                         }


### PR DESCRIPTION
added compatible code for shopware >= 6.4 and <

the new code will change the selected iDeal issuer on dropdown value changed

the old code somehow didnt work in 6.3.5.2, so i've changed the event handler from a "form listener" to a "button click" listener, which worked

i also added 2 cypress tests that evaluate that a pre-selected issuer is being sent with the payment request.
in that case, there will immediately be a payment status form instead of an additional issuer-selection list in Mollie
that asserts that an existing issuer has been set

