### PR TITLE
Add editorconfig for json files to force indenting to 2 spaces.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.json]
+indent_size = 2

--- a/makefile
+++ b/makefile
@@ -54,4 +54,4 @@ pr: ## Prepares everything for a Pull Request
 
 release: ## Creates a new ZIP package
 	@cd .. && rm -rf MolliePayments-$(PLUGIN_VERSION).zip
-	@cd .. && zip -qq -r -0 MolliePayments-$(PLUGIN_VERSION).zip MolliePayments/ -x '*.git*' '*.reports*' '*/tests*' '*/makefile' '*.DS_Store' '*/phpunit.xml' '*/.phpstan.neon' '*/.php_cs.php' '*/phpinsights.php'
+	@cd .. && zip -qq -r -0 MolliePayments-$(PLUGIN_VERSION).zip MolliePayments/ -x '.editorconfig' '*.git*' '*.reports*' '*/tests*' '*/makefile' '*.DS_Store' '*/phpunit.xml' '*/.phpstan.neon' '*/.php_cs.php' '*/phpinsights.php'


### PR DESCRIPTION
Added an editor config file to force .json files to use 2 spaces as indentation. The editor config that comes with the Shopware development template forces everything to 4 spaces, and DIW seems to use 2 spaces. This will force everyone to use 2 spaces for this repository.