### PR TITLE
MOL-504: add backwards compatibility

### DIFF
--- a/src/Controller/Api/OrderController.php
+++ b/src/Controller/Api/OrderController.php
@@ -74,7 +74,7 @@ class OrderController extends AbstractController
         }
 
         return new JsonResponse([
-            'url' => $this->mollieOrderService->getPaymentUrl($mollieOrderId, $order->getSalesChannelId()),
+            'url' => $this->mollieOrderService->getPaymentUrl($mollieOrderId, $order->getSalesChannel()->getId()),
         ]);
     }
 }

--- a/src/Controller/Api/RefundController.php
+++ b/src/Controller/Api/RefundController.php
@@ -205,14 +205,14 @@ class RefundController extends AbstractController
             && $quantity > 0
         ) {
             $apiClient = $this->apiFactory->createClient(
-                $orderLineItem->getOrder()->getSalesChannelId()
+                $orderLineItem->getOrder()->getSalesChannel()->getId()
             );
         }
 
         if ($apiClient !== null) {
             /** @var MollieSettingStruct $settings */
             $settings = $this->settingsService->getSettings(
-                $orderLineItem->getOrder()->getSalesChannelId()
+                $orderLineItem->getOrder()->getSalesChannel()->getId()
             );
 
             /** @var array $orderParameters */

--- a/src/Controller/Api/ShippingController.php
+++ b/src/Controller/Api/ShippingController.php
@@ -156,14 +156,14 @@ class ShippingController extends AbstractController
             && $quantity > 0
         ) {
             $apiClient = $this->apiFactory->createClient(
-                $orderLineItem->getOrder()->getSalesChannelId()
+                $orderLineItem->getOrder()->getSalesChannel()->getId()
             );
         }
 
         if ($apiClient !== null) {
             /** @var MollieSettingStruct $settings */
             $settings = $this->settingsService->getSettings(
-                $orderLineItem->getOrder()->getSalesChannelId()
+                $orderLineItem->getOrder()->getSalesChannel()->getId()
             );
 
             /** @var array $orderParameters */
@@ -310,14 +310,14 @@ class ShippingController extends AbstractController
             && $quantity > 0
         ) {
             $apiClient = $this->apiFactory->createClient(
-                $orderLineItem->getOrder()->getSalesChannelId()
+                $orderLineItem->getOrder()->getSalesChannel()->getId()
             );
         }
 
         if ($apiClient !== null) {
             /** @var MollieSettingStruct $settings */
             $settings = $this->settingsService->getSettings(
-                $orderLineItem->getOrder()->getSalesChannelId()
+                $orderLineItem->getOrder()->getSalesChannel()->getId()
             );
 
             /** @var array $orderParameters */

--- a/src/Exception/MissingSalesChannelInOrder.php
+++ b/src/Exception/MissingSalesChannelInOrder.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Kiener\MolliePayments\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class MissingSalesChannelInOrder extends ShopwareHttpException
+{
+    public function __construct(string $orderNumber)
+    {
+        $message = sprintf('Could not extract SalesChannel from order (%s)', $orderNumber);
+        parent::__construct($message);
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'MOLLIE_PAYMENTS__MISSING_SALESCHANNEL_IN_ORDER';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+}

--- a/src/Facade/MollieShipment.php
+++ b/src/Facade/MollieShipment.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 class MollieShipment
 {
@@ -94,7 +95,20 @@ class MollieShipment
             return false;
         }
 
-        $addedMollieShipment = $this->mollieApiOrderService->setShipment($mollieOrderId, $order->getSalesChannelId());
+        $salesChannel = $order->getSalesChannel();
+
+        if (!$salesChannel instanceof SalesChannelEntity) {
+            $this->logger->warning(
+                sprintf(
+                    'Could not extract SalesChannel from order (%s)',
+                    (string)$order->getOrderNumber()
+                )
+            );
+
+            return false;
+        }
+
+        $addedMollieShipment = $this->mollieApiOrderService->setShipment($mollieOrderId, $salesChannel->getId());
 
         if ($addedMollieShipment) {
             $values = [CustomFieldsInterface::DELIVERY_SHIPPED => true];

--- a/src/Facade/Notifications/NotificationFacade.php
+++ b/src/Facade/Notifications/NotificationFacade.php
@@ -95,7 +95,7 @@ class NotificationFacade
 
         # --------------------------------------------------------------------------------------------
 
-        $this->gatewayMollie->switchClient($contextSC->getSalesChannelId());
+        $this->gatewayMollie->switchClient($contextSC->getSalesChannel()->getId());
 
         # fetch the order of our mollie ID
         # from our sales channel mollie profile

--- a/src/Service/MollieApi/Order.php
+++ b/src/Service/MollieApi/Order.php
@@ -26,7 +26,7 @@ class Order
         $this->logger = $logger;
     }
 
-    public function getMollieOrder(string $mollieOrderId, string $salesChannelId): MollieOrder
+    public function getMollieOrder(string $mollieOrderId, ?string $salesChannelId): MollieOrder
     {
         $apiClient = $this->clientFactory->getClient($salesChannelId);
 
@@ -52,7 +52,7 @@ class Order
         return $mollieOrder->status === 'created' ? $mollieOrder->getCheckoutUrl() : null;
     }
 
-    public function setShipment(string $mollieOrderId, string $salesChannelId): bool
+    public function setShipment(string $mollieOrderId, ?string $salesChannelId): bool
     {
         $mollieOrder = $this->getMollieOrder($mollieOrderId, $salesChannelId);
 

--- a/src/Subscriber/OrderDeliverySubscriber.php
+++ b/src/Subscriber/OrderDeliverySubscriber.php
@@ -3,11 +3,10 @@
 namespace Kiener\MolliePayments\Subscriber;
 
 use Kiener\MolliePayments\Facade\MollieShipment;
-use Kiener\MolliePayments\Service\SettingsService;
-use Mollie\Api\MollieApiClient;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
 use Shopware\Core\System\StateMachine\Event\StateMachineStateChangeEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Throwable;
 
 class OrderDeliverySubscriber implements EventSubscriberInterface
 {

--- a/src/Subscriber/PaymentStateSubscriber.php
+++ b/src/Subscriber/PaymentStateSubscriber.php
@@ -3,6 +3,7 @@
 namespace Kiener\MolliePayments\Subscriber;
 
 use Kiener\MolliePayments\Exception\CouldNotSetRefundAtMollieException;
+use Kiener\MolliePayments\Exception\MissingSalesChannelInOrder;
 use Kiener\MolliePayments\Facade\SetMollieOrderRefunded;
 use Kiener\MolliePayments\Service\LoggerService;
 use Monolog\Logger;
@@ -58,7 +59,7 @@ class PaymentStateSubscriber implements EventSubscriberInterface
 
         try {
             $this->setMollieOrderRefunded->setRefunded($event->getTransition()->getEntityId(), $event->getContext());
-        } catch (CouldNotSetRefundAtMollieException $e) {
+        } catch (CouldNotSetRefundAtMollieException | MissingSalesChannelInOrder $e) {
             $this->loggerService->addEntry(
                 $e->getMessage(),
                 $event->getContext(),

--- a/src/Subscriber/TestModeNotificationSubscriber.php
+++ b/src/Subscriber/TestModeNotificationSubscriber.php
@@ -42,7 +42,7 @@ class TestModeNotificationSubscriber implements EventSubscriberInterface
 
     public function addTestModeInformationToPages(PageLoadedEvent $event): void
     {
-        $settings = $this->settingsService->getSettings($event->getSalesChannelContext()->getSalesChannelId());
+        $settings = $this->settingsService->getSettings($event->getSalesChannelContext()->getSalesChannel()->getId());
         $event->getPage()->addExtension('MollieTestModePageExtension', new TestModePageExtensionStruct($settings->isTestMode()));
     }
 }

--- a/tests/Cypress/package.json
+++ b/tests/Cypress/package.json
@@ -1,9 +1,0 @@
-{
-  "devDependencies": {
-    "@cucumber/tag-expressions": "^3.0.1",
-    "@cypress/webpack-preprocessor": "^5.9.1",
-    "axios": "^0.21.1",
-    "cypress": "^7.6.0",
-    "webpack": "^4.18.1"
-  }
-}

--- a/tests/Cypress/package.json
+++ b/tests/Cypress/package.json
@@ -1,0 +1,9 @@
+{
+  "devDependencies": {
+    "@cucumber/tag-expressions": "^3.0.1",
+    "@cypress/webpack-preprocessor": "^5.9.1",
+    "axios": "^0.21.1",
+    "cypress": "^7.6.0",
+    "webpack": "^4.18.1"
+  }
+}

--- a/tests/PHPUnit/Facade/MollieShipmentTest.php
+++ b/tests/PHPUnit/Facade/MollieShipmentTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 class MollieShipmentTest extends TestCase
 {
@@ -155,8 +156,10 @@ class MollieShipmentTest extends TestCase
         $mollieOrderId = 'foo';
         $customFields[CustomFieldsInterface::MOLLIE_KEY][CustomFieldsInterface::ORDER_KEY] = $mollieOrderId;
         $order->setCustomFields($customFields);
+        $salesChannel = $this->getMockBuilder(SalesChannelEntity::class)->disableOriginalConstructor()->getMock();
         $salesChannelId = 'bar';
-        $order->setSalesChannelId($salesChannelId);
+        $salesChannel->method('getId')->willReturn($salesChannelId);
+        $order->setSalesChannel($salesChannel);
         $delivery = $this->createDelivery($order);
         $deliveryId = $delivery->getId();
         $this->orderDeliveryService->method('getDelivery')->willReturn($delivery);
@@ -182,7 +185,9 @@ class MollieShipmentTest extends TestCase
         $customFields[CustomFieldsInterface::MOLLIE_KEY][CustomFieldsInterface::ORDER_KEY] = $mollieOrderId;
         $order->setCustomFields($customFields);
         $salesChannelId = 'bar';
-        $order->setSalesChannelId($salesChannelId);
+        $salesChannel = $this->getMockBuilder(SalesChannelEntity::class)->disableOriginalConstructor()->getMock();
+        $salesChannel->method('getId')->willReturn($salesChannelId);
+        $order->setSalesChannel($salesChannel);
         $delivery = $this->createDelivery($order);
         $deliveryId = $delivery->getId();
         $this->orderDeliveryService->method('getDelivery')->willReturn($delivery);

--- a/tests/PHPUnit/Facade/SetMollieOrderRefundedTest.php
+++ b/tests/PHPUnit/Facade/SetMollieOrderRefundedTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEnti
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 class SetMollieOrderRefundedTest extends TestCase
 {
@@ -148,7 +149,9 @@ class SetMollieOrderRefundedTest extends TestCase
     {
         $order = new OrderEntity();
         $order->setId($orderId);
-        $order->setSalesChannelId($salesChannelId);
+        $salesChannel = $this->getMockBuilder(SalesChannelEntity::class)->disableOriginalConstructor()->getMock();
+        $salesChannel->method('getId')->willReturn($salesChannelId);
+        $order->setSalesChannel($salesChannel);
 
         if (!empty($customFields)) {
             $order->setCustomFields($customFields);


### PR DESCRIPTION
in SW versions < 6.3 there is no method getSalesChannelId in SalesChannelContext