### PR TITLE
MOL-572: Fix broken Retry Payment Not Found error

### DIFF
--- a/src/Storefront/Controller/PaymentController.php
+++ b/src/Storefront/Controller/PaymentController.php
@@ -250,20 +250,21 @@ class PaymentController extends StorefrontController
 
     /**
      * @RouteScope(scopes={"storefront"})
-     * @Route("/mollie/payment/retry/{transactionId}/{redirectUrl}", defaults={"csrf_protected"=false},
+     * @Route("/mollie/payment/retry/{transactionId}", defaults={"csrf_protected"=false},
      *                                                               name="frontend.mollie.payment.retry",
      *                                                               options={"seo"="false"}, methods={"GET", "POST"})
      *
      * @param SalesChannelContext $context
      * @param                     $transactionId
-     *
-     * @param                     $redirectUrl
-     *
      * @return Response|RedirectResponse
      * @throws Exception
      */
-    public function retry(SalesChannelContext $context, $transactionId, $redirectUrl): RedirectResponse
+    public function retry(SalesChannelContext $context, $transactionId): RedirectResponse
     {
+        # keep compatible to older Shopware versions by avoiding
+        # the Parameter Bag
+        $redirectUrl = (string)$_GET['redirectUrl'];
+
         /** @var string $redirectUrl */
         $redirectUrl = urldecode($redirectUrl);
 


### PR DESCRIPTION
somehow the url parameter isnt valid anymore in the latest shopware version.
as soon as there is an encoded :// in there from http....then its somewhere caught from the router
and this leads to a Not Found page

so i just removed the param and added the url as GET parameter,
Cypress is now green again locally