### PR TITLE
NTR: Correct ApplePay merchantCapabilities

### DIFF
--- a/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-direct.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-direct.plugin.js
@@ -151,7 +151,7 @@ export default class MollieApplePayDirect extends Plugin {
                 'visa',
                 'vPay',
             ],
-            merchantCapabilities: ['supports3DS', 'supportsEMV', 'supportsCredit', 'supportsDebit'],
+            merchantCapabilities: ['supports3DS'],
             total: {
                 label: '',
                 amount: 0,


### PR DESCRIPTION
See mollie/api-documentation#816

When we signal `supportsEMV` to the client, we might receive a cryptogram that cannot be processed by Mollie under certain circumstances.

Additionally, `supportsCredit` and `supportsDebit` are superfluous together, as this [Apple Doc](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaymerchantcapability) states them as optional and we support both.