### PR TITLE
Add check for refunds array if it is not undefined

### DIFF
--- a/src/Resources/app/administration/src/module/mollie-payments/extension/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/extension/sw-order/component/sw-order-line-items-grid/index.js
@@ -88,7 +88,7 @@ Component.override('sw-order-line-items-grid', {
         },
 
         canOpenRefundModal() {
-            return this.remainingAmount > 0 || (this.refunds && this.refunds.length > 0);
+            return this.remainingAmount > 0 || (this.refunds !== undefined && this.refunds.length > 0);
         },
     },
 

--- a/src/Resources/app/administration/src/module/mollie-payments/extension/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/extension/sw-order/component/sw-order-line-items-grid/index.js
@@ -88,7 +88,7 @@ Component.override('sw-order-line-items-grid', {
         },
 
         canOpenRefundModal() {
-            return this.remainingAmount > 0 || this.refunds.length > 0;
+            return this.remainingAmount > 0 || (this.refunds && this.refunds.length > 0);
         },
     },
 


### PR DESCRIPTION
In a shop for a client, I was having an issue when using mollie credit card payment that the order items in the order details was not showing up in the admin section. The error was giving an "undefined" error at this point when reading the length property. Adding an additional check here for refunds array if it is available before checking for length solves the problem.

![image](https://user-images.githubusercontent.com/24492269/139791657-ed6c5701-a1ba-4899-bec7-fa12a4d2ef04.png)
