### PR TITLE
MOL-632: Plugin Compatibility Acris Shipping Preselect

### DIFF
--- a/src/Compatibility/Storefront/Route/PaymentMethodRoute/Voucher/HideVoucherPaymentMethodRoute62.php
+++ b/src/Compatibility/Storefront/Route/PaymentMethodRoute/Voucher/HideVoucherPaymentMethodRoute62.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Payment\SalesChannel\AbstractPaymentMethodRoute;
 use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRouteResponse;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 
 
@@ -21,24 +22,25 @@ class HideVoucherPaymentMethodRoute62 extends AbstractPaymentMethodRoute
     private $corePaymentMethodRoute;
 
     /**
-     * @var CartService
-     */
-    private $cartService;
-
-    /**
      * @var VoucherService
      */
     private $voucherService;
 
     /**
+     * @var Container
+     */
+    private $container;
+
+
+    /**
      * @param AbstractPaymentMethodRoute $corePaymentMethodRoute
-     * @param CartService $cartService
+     * @param Container $container
      * @param VoucherService $voucherService
      */
-    public function __construct(AbstractPaymentMethodRoute $corePaymentMethodRoute, CartService $cartService, VoucherService $voucherService)
+    public function __construct(AbstractPaymentMethodRoute $corePaymentMethodRoute, Container $container, VoucherService $voucherService)
     {
         $this->corePaymentMethodRoute = $corePaymentMethodRoute;
-        $this->cartService = $cartService;
+        $this->container = $container;
         $this->voucherService = $voucherService;
     }
 
@@ -65,7 +67,8 @@ class HideVoucherPaymentMethodRoute62 extends AbstractPaymentMethodRoute
     {
         $originalData = $this->corePaymentMethodRoute->load($request, $context);
 
-        $cart = $this->cartService->getCart($context->getToken(), $context);
+        $cartService = $this->getCartServiceLazy();
+        $cart = $cartService->getCart($context->getToken(), $context);
 
         $voucherPermitted = (bool)$cart->getData()->get(VoucherCartCollector::VOUCHER_PERMITTED);
 
@@ -86,6 +89,24 @@ class HideVoucherPaymentMethodRoute62 extends AbstractPaymentMethodRoute
         }
 
         return $originalData;
+    }
+
+    /**
+     * We have to use lazy loading for this. Otherwise there are plugin compatibilities
+     * with a circular reference...even though XML looks fine.
+     *
+     * @return CartService
+     * @throws \Exception
+     */
+    private function getCartServiceLazy(): CartService
+    {
+        $service = $this->container->get('Shopware\Core\Checkout\Cart\SalesChannel\CartService');
+
+        if (!$service instanceof CartService) {
+            throw new \Exception('CartService of Shopware not found!');
+        }
+
+        return $service;
     }
 
 }

--- a/src/Compatibility/Storefront/Route/PaymentMethodRoute/Voucher/HideVoucherPaymentMethodRoute64.php
+++ b/src/Compatibility/Storefront/Route/PaymentMethodRoute/Voucher/HideVoucherPaymentMethodRoute64.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Payment\SalesChannel\AbstractPaymentMethodRoute;
 use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRouteResponse;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 
 
@@ -21,24 +22,25 @@ class HideVoucherPaymentMethodRoute64 extends AbstractPaymentMethodRoute
     private $corePaymentMethodRoute;
 
     /**
-     * @var CartService
-     */
-    private $cartService;
-
-    /**
      * @var VoucherService
      */
     private $voucherService;
 
     /**
+     * @var Container
+     */
+    private $container;
+
+
+    /**
      * @param AbstractPaymentMethodRoute $corePaymentMethodRoute
-     * @param CartService $cartService
+     * @param Container $container
      * @param VoucherService $voucherService
      */
-    public function __construct(AbstractPaymentMethodRoute $corePaymentMethodRoute, CartService $cartService, VoucherService $voucherService)
+    public function __construct(AbstractPaymentMethodRoute $corePaymentMethodRoute, Container $container, VoucherService $voucherService)
     {
         $this->corePaymentMethodRoute = $corePaymentMethodRoute;
-        $this->cartService = $cartService;
+        $this->container = $container;
         $this->voucherService = $voucherService;
     }
 
@@ -61,8 +63,8 @@ class HideVoucherPaymentMethodRoute64 extends AbstractPaymentMethodRoute
     {
         $originalData = $this->corePaymentMethodRoute->load($request, $context, $criteria);
 
-        $cart = $this->cartService->getCart($context->getToken(), $context);
-
+        $cartService = $this->getCartServiceLazy();
+        $cart = $cartService->getCart($context->getToken(), $context);
 
         $voucherPermitted = (bool)$cart->getData()->get(VoucherCartCollector::VOUCHER_PERMITTED);
 
@@ -83,6 +85,24 @@ class HideVoucherPaymentMethodRoute64 extends AbstractPaymentMethodRoute
         }
 
         return $originalData;
+    }
+
+    /**
+     * We have to use lazy loading for this. Otherwise there are plugin compatibilities
+     * with a circular reference...even though XML looks fine.
+     *
+     * @return CartService
+     * @throws \Exception
+     */
+    private function getCartServiceLazy(): CartService
+    {
+        $service = $this->container->get('Shopware\Core\Checkout\Cart\SalesChannel\CartService');
+
+        if (!$service instanceof CartService) {
+            throw new \Exception('CartService of Shopware not found!');
+        }
+
+        return $service;
     }
 
 }

--- a/src/Resources/config/compatibility/services_6.2.xml
+++ b/src/Resources/config/compatibility/services_6.2.xml
@@ -9,7 +9,7 @@
         <service id="Kiener\MolliePayments\Compatibility\Storefront\Route\PaymentMethodRoute\Voucher\HideVoucherPaymentMethodRoute62"
                  decorates="Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute">
             <argument type="service" id="Kiener\MolliePayments\Compatibility\Storefront\Route\PaymentMethodRoute\Voucher\HideVoucherPaymentMethodRoute62.inner"/>
-            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="service_container"/>
             <argument type="service" id="Kiener\MolliePayments\Service\Voucher\VoucherService"/>
         </service>
 

--- a/src/Resources/config/compatibility/services_6.3.xml
+++ b/src/Resources/config/compatibility/services_6.3.xml
@@ -9,7 +9,7 @@
         <service id="Kiener\MolliePayments\Compatibility\Storefront\Route\PaymentMethodRoute\Voucher\HideVoucherPaymentMethodRoute63"
                  decorates="Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute">
             <argument type="service" id="Kiener\MolliePayments\Compatibility\Storefront\Route\PaymentMethodRoute\Voucher\HideVoucherPaymentMethodRoute63.inner"/>
-            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="service_container"/>
             <argument type="service" id="Kiener\MolliePayments\Service\Voucher\VoucherService"/>
         </service>
 

--- a/src/Resources/config/compatibility/services_6.4.xml
+++ b/src/Resources/config/compatibility/services_6.4.xml
@@ -9,7 +9,7 @@
         <service id="Kiener\MolliePayments\Compatibility\Storefront\Route\PaymentMethodRoute\Voucher\HideVoucherPaymentMethodRoute64"
                  decorates="Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute">
             <argument type="service" id="Kiener\MolliePayments\Compatibility\Storefront\Route\PaymentMethodRoute\Voucher\HideVoucherPaymentMethodRoute64.inner"/>
-            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="service_container"/>
             <argument type="service" id="Kiener\MolliePayments\Service\Voucher\VoucherService"/>
         </service>
 


### PR DESCRIPTION
due to some looooong dependency chains, theres a circular reference.

the only option is to change to lazy-loading for the CartService.

The cart service unfortunately reloads the decorated CartRule of Acris...which leads to our problem.