### PR TITLE
MOL-635: Failed payments have status cancelled instead of failed

### DIFF
--- a/src/Facade/MolliePaymentFinalize.php
+++ b/src/Facade/MolliePaymentFinalize.php
@@ -13,6 +13,7 @@ use Kiener\MolliePayments\Struct\MollieOrderCustomFieldsStruct;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\Exceptions\IncompatiblePlatform;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
+use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
 use Shopware\Core\Checkout\Payment\Exception\CustomerCanceledAsyncPaymentException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -40,11 +41,11 @@ class MolliePaymentFinalize
     private $settingsService;
 
     public function __construct(
-        MollieApiFactory $mollieApiFactory,
+        MollieApiFactory                      $mollieApiFactory,
         TransactionTransitionServiceInterface $transactionTransitionService,
-        OrderStatusConverter $orderStatusConverter,
-        OrderStatusUpdater $orderStatusUpdater,
-        SettingsService $settingsService
+        OrderStatusConverter                  $orderStatusConverter,
+        OrderStatusUpdater                    $orderStatusUpdater,
+        SettingsService                       $settingsService
     )
     {
         $this->mollieApiFactory = $mollieApiFactory;
@@ -76,21 +77,49 @@ class MolliePaymentFinalize
         $apiClient = $this->mollieApiFactory->getClient($salesChannelContext->getSalesChannel()->getId());
         $mollieOrder = $apiClient->orders->get($mollieOrderId, ['embed' => 'payments']);
 
-        $paymentStatus = $this->orderStatusConverter->getMollieStatus($mollieOrder);
-        $this->orderStatusUpdater->updatePaymentStatus($transactionStruct->getOrderTransaction(), $paymentStatus, $salesChannelContext->getContext());
         $settings = $this->settingsService->getSettings($salesChannelContext->getSalesChannel()->getId());
-        $this->orderStatusUpdater->updateOrderStatus($order, $paymentStatus, $settings, $salesChannelContext->getContext());
 
-        if (MolliePaymentStatus::isFailedStatus($paymentStatus)) {
 
-            throw new CustomerCanceledAsyncPaymentException(
-                $transactionStruct->getOrderTransaction()->getUniqueIdentifier(),
-                sprintf(
-                    'Payment for order %s (%s) was cancelled by the customer.',
-                    $order->getOrderNumber(),
-                    $mollieOrder->id
-                )
-            );
+        $paymentStatus = $this->orderStatusConverter->getMollieStatus($mollieOrder);
+
+
+        # Attention
+        # Our payment status will either be set by us, or automatically by Shopware using exceptions below.
+        # But the order status, is something that we always have to set MANUALLY in both cases.
+        # That's why we do this here, before throwing exceptions.
+        $this->orderStatusUpdater->updateOrderStatus(
+            $order,
+            $paymentStatus,
+            $settings,
+            $salesChannelContext->getContext()
+        );
+
+
+        # now either set the payment status for successful payments
+        # or make sure to throw an exception for Shopware in case
+        # of failed payments.
+        if (!MolliePaymentStatus::isFailedStatus($paymentStatus)) {
+
+            $this->orderStatusUpdater->updatePaymentStatus($transactionStruct->getOrderTransaction(), $paymentStatus, $salesChannelContext->getContext());
+
+        } else {
+
+            $orderTransactionID = $transactionStruct->getOrderTransaction()->getUniqueIdentifier();
+
+            # let's also create a different handling, if the customer either cancelled
+            # or if the payment really failed. this will lead to a different order payment status in the end.
+            if ($paymentStatus === MolliePaymentStatus::MOLLIE_PAYMENT_CANCELED) {
+
+                $message = sprintf('Payment for order %s (%s) was cancelled by the customer.', $order->getOrderNumber(), $mollieOrder->id);
+
+                throw new CustomerCanceledAsyncPaymentException($orderTransactionID, $message);
+
+            } else {
+
+                $message = sprintf('Payment for order %s (%s) failed. The Mollie payment status was not successful for this payment attempt.', $order->getOrderNumber(), $mollieOrder->id);
+
+                throw new AsyncPaymentFinalizeException($orderTransactionID, $message);
+            }
         }
     }
 }

--- a/src/Handler/PaymentHandler.php
+++ b/src/Handler/PaymentHandler.php
@@ -9,20 +9,15 @@ use Kiener\MolliePayments\Service\LoggerService;
 use Kiener\MolliePayments\Service\Transition\TransactionTransitionServiceInterface;
 use Mollie\Api\Exceptions\ApiException;
 use Monolog\Logger;
-use RuntimeException;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentFinalizeException;
 use Shopware\Core\Checkout\Payment\Exception\CustomerCanceledAsyncPaymentException;
-use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\Locale\LocaleEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\StateMachine\Exception\IllegalTransitionException;
-use Shopware\Core\System\StateMachine\Exception\StateMachineInvalidEntityIdException;
-use Shopware\Core\System\StateMachine\Exception\StateMachineInvalidStateFieldException;
-use Shopware\Core\System\StateMachine\Exception\StateMachineNotFoundException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Throwable;
@@ -155,48 +150,40 @@ class PaymentHandler implements AsynchronousPaymentHandlerInterface
     }
 
     /**
-     * The finalize function will be called when the user is redirected back to shop from the payment gateway.
      *
-     * Throw a
-     *
-     * @param AsyncPaymentTransactionStruct $transaction
-     * @param Request $request
-     * @param SalesChannelContext $salesChannelContext @see AsyncPaymentFinalizeException exception if an
-     *                                                           error ocurres while calling an external payment API
-     *                                                           Throw a @throws RuntimeException*@throws
-     *                                                           CustomerCanceledAsyncPaymentException
-     *
-     * @throws CustomerCanceledAsyncPaymentException
-     * @throws InconsistentCriteriaIdsException
-     * @throws IllegalTransitionException
-     * @throws StateMachineInvalidEntityIdException
-     * @throws StateMachineInvalidStateFieldException
-     * @throws StateMachineNotFoundException
-     * @see CustomerCanceledAsyncPaymentException exception if the customer canceled the payment process on
-     * payment provider page
      */
     public function finalize(AsyncPaymentTransactionStruct $transaction, Request $request, SalesChannelContext $salesChannelContext): void
     {
         try {
+
             $this->finalizeFacade->finalize($transaction, $salesChannelContext);
-        } catch (CustomerCanceledAsyncPaymentException $exception) {
-            throw $exception;
+
+        } catch (AsyncPaymentFinalizeException | CustomerCanceledAsyncPaymentException $ex) {
+
+            # these are already correct exceptions
+            # that cancel the Shopware order in a coordinated way by Shopware
+            throw $ex;
+
         } catch (Throwable $exception) {
-            $e = null;
-            if ($exception instanceof \Exception) {
-                $e = $exception;
-            }
+
+            # this processes all unhandled exceptions.
+            # we need to log whatever happens in here, and then also
+            # throw an exception that breaks the order in a coordinated way.
+            # Only the 2 exceptions above, lead to a correct failure-behaviour in Shopware.
+            # All other exceptions would lead to a 500 exception in the storefront.
+
             $this->logger->addEntry(
                 $exception->getMessage(),
                 $salesChannelContext->getContext(),
-                $e,
+                ($exception instanceof \Exception) ? $exception : null,
                 null,
                 Logger::ERROR
             );
 
-            # ATTENTION, the second empty parameter is required
-            # in earlier Shopware 6.1.x versions, this was NOT optional!
-            throw new CustomerCanceledAsyncPaymentException($transaction->getOrderTransaction()->getId(), '');
+            throw new AsyncPaymentFinalizeException(
+                $transaction->getOrderTransaction()->getId(),
+                'An unknown error happened when finalizing the order. Please see the Shopware logs for more. It can be that the payment in Mollie was succesful and the Shopware order is now cancelled or failed!'
+            );
         }
     }
 }

--- a/tests/Cypress/cypress/integration/storefront/checkout/checkout-states.spec.js
+++ b/tests/Cypress/cypress/integration/storefront/checkout/checkout-states.spec.js
@@ -91,7 +91,7 @@ context("Order Status Mapping Tests", () => {
 
             adminLogin.login();
             adminOrders.assertLatestOrderStatus('Open');
-            adminOrders.assertLatestPaymentStatus('Cancelled');
+            adminOrders.assertLatestPaymentStatus('Failed');
         })
 
         it('Test Status Cancelled', () => {

--- a/tests/Cypress/makefile
+++ b/tests/Cypress/makefile
@@ -27,7 +27,7 @@ ifndef url
 	@exit 1
 endif
 ifndef shopware
-	CYPRESS_BASE_URL=$(url) CYPRESS_SHOPWARE=6.4 ./node_modules/.bin/cypress open --env conf=dev
+	CYPRESS_BASE_URL=$(url) CYPRESS_SHOPWARE=6.4.6.0 ./node_modules/.bin/cypress open --env conf=dev
 else
 	CYPRESS_BASE_URL=$(url) CYPRESS_SHOPWARE=$(shopware) ./node_modules/.bin/cypress open --env conf=dev
 endif


### PR DESCRIPTION
with the shopware default behaviour for failed payments,
the failed payments lead to a status "cancelled".

so we only do this if its really cancelled,
otherwise it should be an exception that leads to the status "failed"