### PR TITLE
NTR: Ignore compiled admin css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 
 src/Resources/app/storefront/dist/
 
+src/Resources/public/administration/css/
 src/Resources/public/administration/js/


### PR DESCRIPTION
Similar to the compiled JS, the compiled CSS should also not be in the repository, but should be built before preparing a release.