### PR TITLE
NTR: Ignore node modules in administration and storefront

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,9 @@
 /tests/Cypress/package-lock.json
 
 src/Resources/app/administration/node_modules
-src/Resources/app/administration/package-lock.json
 
 src/Resources/app/storefront/dist/
 src/Resources/app/storefront/node_modules
-src/Resources/app/storefront/package-lock.json
 
 src/Resources/public/administration/css/
 src/Resources/public/administration/js/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,12 @@
 .DS_Store
 /tests/Cypress/package-lock.json
 
+src/Resources/app/administration/node_modules
+src/Resources/app/administration/package-lock.json
+
 src/Resources/app/storefront/dist/
+src/Resources/app/storefront/node_modules
+src/Resources/app/storefront/package-lock.json
 
 src/Resources/public/administration/css/
 src/Resources/public/administration/js/

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 
 src/Resources/app/storefront/dist/
 
+src/Resources/public/administration/css/
 src/Resources/public/administration/js/

--- a/src/Resources/app/administration/package.json
+++ b/src/Resources/app/administration/package.json
@@ -3,8 +3,7 @@
     "version": "1.0.0",
     "description": "",
     "author": "Mollie B.V.",
-    "dependencies": {
-    },
+    "dependencies": {},
     "devDependencies": {
         "@babel/cli": "^7.5.5",
         "@babel/core": "^7.5.5",

--- a/src/Resources/app/storefront/package.json
+++ b/src/Resources/app/storefront/package.json
@@ -2,9 +2,8 @@
     "name": "mollie-shopware6-storefront-tests",
     "version": "1.0.0",
     "description": "",
-  "author": "Mollie B.V.",
-    "dependencies": {
-    },
+    "author": "Mollie B.V.",
+    "dependencies": {},
     "devDependencies": {
         "@babel/cli": "^7.5.5",
         "@babel/core": "^7.5.5",


### PR DESCRIPTION
Another small update to ignore node_modules when all the dev dependencies are installed.

#219 is on the roadmap so package-lock.json is not ignored.