### PR TITLE
NTR: Attribute system

### DIFF
--- a/.phpstan.lvl8.neon
+++ b/.phpstan.lvl8.neon
@@ -16,6 +16,7 @@ parameters:
         # legacy code that is not working with abstract/interface changes
         - ./src/Compatibility/Storefront/Route/PaymentMethodRoute/Voucher/HideVoucherPaymentMethodRoute63.php
         - ./src/Compatibility/Storefront/Route/PaymentMethodRoute/Voucher/HideVoucherPaymentMethodRoute62.php
+        - ./src/Struct/Attribute/AttributeStruct.php
 
 services:
     - class: MolliePayments\PHPStan\Rules\NoManufacturerRule

--- a/.phpstan.lvl8.neon
+++ b/.phpstan.lvl8.neon
@@ -16,7 +16,6 @@ parameters:
         # legacy code that is not working with abstract/interface changes
         - ./src/Compatibility/Storefront/Route/PaymentMethodRoute/Voucher/HideVoucherPaymentMethodRoute63.php
         - ./src/Compatibility/Storefront/Route/PaymentMethodRoute/Voucher/HideVoucherPaymentMethodRoute62.php
-        - ./src/Struct/Attribute/AttributeStruct.php
 
 services:
     - class: MolliePayments\PHPStan\Rules\NoManufacturerRule

--- a/src/Struct/Attribute/AttributeCollection.php
+++ b/src/Struct/Attribute/AttributeCollection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kiener\MolliePayments\Struct\Attribute;
+
+use Shopware\Core\Framework\Struct\Collection;
+use Shopware\Core\Framework\Struct\Struct;
+
+abstract class AttributeCollection extends Collection
+{
+    public function getElements(): array
+    {
+        $data = [];
+
+        foreach(parent::getElements() as $key => $value) {
+            if(in_array($key, ['extensions'])) {
+                continue;
+            }
+
+            if($value instanceof Collection) {
+                $data[$key] = $value->getElements();
+                continue;
+            }
+
+            if($value instanceof Struct) {
+                $data[$key] = $value->getVars();
+                continue;
+            }
+
+            $data[$key] = $value;
+        }
+
+        return $data;
+    }
+}

--- a/src/Struct/Attribute/AttributeCollection.php
+++ b/src/Struct/Attribute/AttributeCollection.php
@@ -10,7 +10,7 @@ abstract class AttributeCollection extends Collection
     /**
      * Returns all elements of this collection
      *
-     * @return array
+     * @return array<mixed>
      */
     public function getElements(): array
     {

--- a/src/Struct/Attribute/AttributeCollection.php
+++ b/src/Struct/Attribute/AttributeCollection.php
@@ -7,25 +7,35 @@ use Shopware\Core\Framework\Struct\Struct;
 
 abstract class AttributeCollection extends Collection
 {
+    /**
+     * Returns all elements of this collection
+     *
+     * @return array
+     */
     public function getElements(): array
     {
         $data = [];
 
-        foreach(parent::getElements() as $key => $value) {
-            if(in_array($key, ['extensions'])) {
-                continue;
-            }
-
-            if($value instanceof Collection) {
+        foreach (parent::getElements() as $key => $value) {
+            /**
+             * If $value is a Collection, return the inner elements array
+             */
+            if ($value instanceof Collection) {
                 $data[$key] = $value->getElements();
                 continue;
             }
 
-            if($value instanceof Struct) {
+            /**
+             * If $value is a Struct, return all the properties of the struct
+             */
+            if ($value instanceof Struct) {
                 $data[$key] = $value->getVars();
                 continue;
             }
 
+            /**
+             * Otherwise just set the value in our data array.
+             */
             $data[$key] = $value;
         }
 

--- a/src/Struct/Attribute/AttributeStruct.php
+++ b/src/Struct/Attribute/AttributeStruct.php
@@ -56,6 +56,9 @@ abstract class AttributeStruct extends Struct
              */
             $camelKey = $caseConverter->denormalize($key);
 
+            /**
+             * Store the original key, so we can revert to it when converting back to an array
+             */
             $keyMapping->set($camelKey, $key);
 
             /**
@@ -201,6 +204,10 @@ abstract class AttributeStruct extends Struct
          * Get the extension
          */
         $extension = $this->getExtension($extensionName);
+
+        if(!$extension instanceof Struct) {
+            return new ArrayStruct();
+        }
 
         /**
          * Return it if it's an ArrayStruct

--- a/src/Struct/Attribute/AttributeStruct.php
+++ b/src/Struct/Attribute/AttributeStruct.php
@@ -58,8 +58,14 @@ abstract class AttributeStruct extends Struct
 
             /**
              * Store the original key, so we can revert to it when converting back to an array
+             *
+             * Using offsetSet() instead of set() because:
+             * 1) Shopware is dumb
+             * 2) They both have the same functionality
+             * 3) They added dumb type-hinting to set
+             * https://github.com/shopware/platform/commit/9c4cbe415d33419d9a9c5a3070007bf5cdf0a00e#diff-f21dd8cab48e2967baac4b0d4fb97e6107099f658733615947db47490e31b511R55
              */
-            $keyMapping->set($camelKey, $key);
+            $keyMapping->offsetSet($camelKey, $key);
 
             /**
              * If a construct method exists for this property, call it to set the value.
@@ -92,8 +98,14 @@ abstract class AttributeStruct extends Struct
             /**
              * If the property doesn't exist in this class at all, store the attribute in the additional attribute struct
              * so we don't lose track of it.
+             *
+             * Using offsetSet() instead of set() because:
+             * 1) Shopware is dumb
+             * 2) They both have the same functionality
+             * 3) They added dumb type-hinting to set
+             * https://github.com/shopware/platform/commit/9c4cbe415d33419d9a9c5a3070007bf5cdf0a00e#diff-f21dd8cab48e2967baac4b0d4fb97e6107099f658733615947db47490e31b511R55
              */
-            $additionalAttributes->set($key, $value);
+            $additionalAttributes->offsetSet($key, $value);
         }
     }
 

--- a/src/Struct/Attribute/AttributeStruct.php
+++ b/src/Struct/Attribute/AttributeStruct.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Kiener\MolliePayments\Struct\Attribute;
+
+use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Struct\Collection;
+use Shopware\Core\Framework\Struct\Struct;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+abstract class AttributeStruct extends Struct
+{
+    public function __construct(?array $attributes = [])
+    {
+        $this->reflect();
+
+        $this->addExtension('additionalAttributes', new ArrayStruct());
+
+        if (empty($attributes)) {
+            return;
+        }
+
+        $caseConverter = new CamelCaseToSnakeCaseNameConverter();
+
+        foreach ($attributes as $key => $value) {
+            $camelKey = $caseConverter->denormalize($key);
+
+            $assignMethod = 'assign' . ucfirst($camelKey);
+            if (method_exists($this, $assignMethod)) {
+                $this->$assignMethod($value);
+                continue;
+            }
+
+            $setMethod = 'set' . ucfirst($camelKey);
+            if (method_exists($this, $setMethod)) {
+                $this->$setMethod($value);
+                continue;
+            }
+
+            if (property_exists($this, $camelKey)) {
+                $this->$camelKey = $value;
+                continue;
+            }
+
+            $this->getExtension('additionalAttributes')->set($key, $value);
+        }
+    }
+
+    public function getVars(): array {
+        $data = $this->hasExtension('additionalAttributes')
+            ? $this->getExtension('additionalAttributes')->all()
+            : [];
+
+        foreach(parent::getVars() as $key => $value) {
+            if(in_array($key, ['extensions'])) {
+                continue;
+            }
+
+            if($value instanceof Collection) {
+                $data[$key] = $value->getElements();
+                continue;
+            }
+
+            if($value instanceof Struct) {
+                $data[$key] = $value->getVars();
+                continue;
+            }
+
+            $data[$key] = $value;
+        }
+
+        return $data;
+    }
+
+    public function toArray(): array {
+        return $this->getVars();
+    }
+
+    public function merge(AttributeStruct $struct): self
+    {
+        foreach($struct->getVars() as $key => $value) {
+            $setMethod = 'set' . ucfirst($key);
+            if(method_exists($this, $setMethod)) {
+                $this->$setMethod($value);
+            }
+        }
+
+        return $this;
+    }
+
+    private function reflect() {
+        $reflectionClass = new \ReflectionClass($this);
+
+        foreach($reflectionClass->getMethods() as $method) {
+            if($method->getDeclaringClass()->getName() !== static::class) {
+                continue;
+            }
+
+            if(!str_starts_with($method->getName(), 'assign')) {
+                continue;
+            }
+
+            if($method->isProtected()) {
+                continue;
+            }
+
+            throw new \Exception(sprintf('Assignment method "%s" should be declared protected.', $method->getName()));
+        }
+    }
+}

--- a/src/Struct/Attribute/AttributeStruct.php
+++ b/src/Struct/Attribute/AttributeStruct.php
@@ -24,7 +24,7 @@ abstract class AttributeStruct extends Struct
         foreach ($attributes as $key => $value) {
             $camelKey = $caseConverter->denormalize($key);
 
-            $assignMethod = 'assign' . ucfirst($camelKey);
+            $assignMethod = 'construct' . ucfirst($camelKey);
             if (method_exists($this, $assignMethod)) {
                 $this->$assignMethod($value);
                 continue;
@@ -97,7 +97,7 @@ abstract class AttributeStruct extends Struct
                 continue;
             }
 
-            if(!str_starts_with($method->getName(), 'assign')) {
+            if(!str_starts_with($method->getName(), 'construct')) {
                 continue;
             }
 

--- a/src/Struct/Attribute/AttributeStruct.php
+++ b/src/Struct/Attribute/AttributeStruct.php
@@ -79,8 +79,10 @@ abstract class AttributeStruct extends Struct
     {
         foreach($struct->getVars() as $key => $value) {
             $setMethod = 'set' . ucfirst($key);
-            if(method_exists($this, $setMethod)) {
+            if (method_exists($this, $setMethod)) {
                 $this->$setMethod($value);
+            } elseif (property_exists($this, $key)) {
+                $this->$key = $value;
             }
         }
 

--- a/src/Struct/Attribute/AttributeStruct.php
+++ b/src/Struct/Attribute/AttributeStruct.php
@@ -76,6 +76,11 @@ abstract class AttributeStruct extends Struct
                 $this->$camelKey = $value;
                 continue;
             }
+            
+            if (property_exists($this, $key)) {
+                $this->$key = $value;
+                continue;
+            }
 
             /**
              * If the property doesn't exist in this class at all, store the attribute in the additional attribute struct

--- a/src/Struct/Attribute/EntityAttributeStruct.php
+++ b/src/Struct/Attribute/EntityAttributeStruct.php
@@ -23,16 +23,13 @@ abstract class EntityAttributeStruct extends AttributeStruct
             throw new \Exception('Entity does not contain custom fields');
         }
 
-        /** TODO 003: Entities always have getTranslated.
-         * If this entity is translatable, for example, product or category, then a method getTranslated is available.
+        /**
          * Use the custom fields from this translated array instead of the regular ones.
          *
          * The getTranslated array contains all the translated fields of this entity, merged on top of the data
          * in the same fields from the default system language.
          */
-        $customFields = method_exists($entity, 'getTranslated')
-            ? $entity->getTranslated()['customFields']
-            : $entity->getCustomFields();
+        $customFields = $entity->getTranslation('customFields') ?? $entity->getCustomFields();
 
         /**
          * If we don't have any custom fields, stop and return.

--- a/src/Struct/Attribute/EntityAttributeStruct.php
+++ b/src/Struct/Attribute/EntityAttributeStruct.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kiener\MolliePayments\Struct\Attribute;
+
+use Kiener\MolliePayments\Service\CustomFieldsInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+
+abstract class EntityAttributeStruct extends AttributeStruct
+{
+    public function __construct(Entity $entity)
+    {
+        if(!method_exists($entity, 'getCustomFields')) {
+            throw new \Exception('Entity does not contain custom fields');
+        }
+
+        $customFields = method_exists($entity, 'getTranslated')
+            ? $entity->getTranslated()['customFields']
+            : $entity->getCustomFields();
+
+        if(empty($customFields)) {
+            return;
+        }
+
+        if (!array_key_exists(CustomFieldsInterface::MOLLIE_KEY, $customFields)) {
+            return;
+        }
+
+        $attributes = $customFields[CustomFieldsInterface::MOLLIE_KEY];
+
+        parent::__construct($attributes);
+    }
+}

--- a/src/Struct/Attribute/EntityAttributeStruct.php
+++ b/src/Struct/Attribute/EntityAttributeStruct.php
@@ -7,6 +7,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 
 abstract class EntityAttributeStruct extends AttributeStruct
 {
+    /**
+     * @param Entity $entity
+     * @throws \Exception
+     */
     public function __construct(Entity $entity)
     {
         if(!method_exists($entity, 'getCustomFields')) {
@@ -28,5 +32,13 @@ abstract class EntityAttributeStruct extends AttributeStruct
         $attributes = $customFields[CustomFieldsInterface::MOLLIE_KEY];
 
         parent::__construct($attributes);
+    }
+
+    /**
+     * @return array
+     */
+    public function toMollieCustomFields(): array
+    {
+        return [CustomFieldsInterface::MOLLIE_KEY => $this->toArray()];
     }
 }

--- a/src/Struct/Attribute/EntityAttributeStruct.php
+++ b/src/Struct/Attribute/EntityAttributeStruct.php
@@ -17,6 +17,7 @@ abstract class EntityAttributeStruct extends AttributeStruct
          * If this entity does not contain getCustomFields, we can't do anything, and we shouldn't even create
          * an attribute struct in the first place.
          */
+        // TODO 001 specific exception
         if(!method_exists($entity, 'getCustomFields')) {
             throw new \Exception('Entity does not contain custom fields');
         }

--- a/src/Struct/Attribute/EntityAttributeStruct.php
+++ b/src/Struct/Attribute/EntityAttributeStruct.php
@@ -13,22 +13,42 @@ abstract class EntityAttributeStruct extends AttributeStruct
      */
     public function __construct(Entity $entity)
     {
+        /**
+         * If this entity does not contain getCustomFields, we can't do anything, and we shouldn't even create
+         * an attribute struct in the first place.
+         */
         if(!method_exists($entity, 'getCustomFields')) {
             throw new \Exception('Entity does not contain custom fields');
         }
 
+        /**
+         * If this entity is translatable, for example, product or category, then a method getTranslated is available.
+         * Use the custom fields from this translated array instead of the regular ones.
+         *
+         * The getTranslated array contains all the translated fields of this entity, merged on top of the data
+         * in the same fields from the default system language.
+         */
         $customFields = method_exists($entity, 'getTranslated')
             ? $entity->getTranslated()['customFields']
             : $entity->getCustomFields();
 
+        /**
+         * If we don't have any custom fields, stop and return.
+         */
         if(empty($customFields)) {
             return;
         }
 
+        /**
+         * Similarly, if the custom fields doesn't have our mollie_payments key, stop.
+         */
         if (!array_key_exists(CustomFieldsInterface::MOLLIE_KEY, $customFields)) {
             return;
         }
 
+        /**
+         * Grab our mollie_payments key and use it to construct our attribute struct
+         */
         $attributes = $customFields[CustomFieldsInterface::MOLLIE_KEY];
 
         parent::__construct($attributes);

--- a/src/Struct/Attribute/EntityAttributeStruct.php
+++ b/src/Struct/Attribute/EntityAttributeStruct.php
@@ -7,8 +7,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 
 abstract class EntityAttributeStruct extends AttributeStruct
 {
-    private const ORIGINAL_ENTITY = 'originalEntity';
-
     /**
      * @param Entity $entity
      * @throws \Exception
@@ -58,8 +56,6 @@ abstract class EntityAttributeStruct extends AttributeStruct
      */
     public function toMollieCustomFields(): array
     {
-        // TODO 002 Use original entity to determine which keys come from the system default language and were not changed
-        // TODO 002 We dont want to return those in the array.
         return [CustomFieldsInterface::MOLLIE_KEY => $this->toArray()];
     }
 }

--- a/src/Struct/Attribute/EntityAttributeStruct.php
+++ b/src/Struct/Attribute/EntityAttributeStruct.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 
 abstract class EntityAttributeStruct extends AttributeStruct
 {
+    private const ORIGINAL_ENTITY = 'originalEntity';
+
     /**
      * @param Entity $entity
      * @throws \Exception
@@ -55,10 +57,12 @@ abstract class EntityAttributeStruct extends AttributeStruct
     }
 
     /**
-     * @return array
+     * @return array<mixed>
      */
     public function toMollieCustomFields(): array
     {
+        // TODO 002 Use original entity to determine which keys come from the system default language and were not changed
+        // TODO 002 We dont want to return those in the array.
         return [CustomFieldsInterface::MOLLIE_KEY => $this->toArray()];
     }
 }

--- a/src/Struct/Attribute/EntityAttributeStruct.php
+++ b/src/Struct/Attribute/EntityAttributeStruct.php
@@ -23,7 +23,7 @@ abstract class EntityAttributeStruct extends AttributeStruct
             throw new \Exception('Entity does not contain custom fields');
         }
 
-        /**
+        /** TODO 003: Entities always have getTranslated.
          * If this entity is translatable, for example, product or category, then a method getTranslated is available.
          * Use the custom fields from this translated array instead of the regular ones.
          *

--- a/tests/PHPUnit/Fakes/Attribute/FakeAttributeCollection.php
+++ b/tests/PHPUnit/Fakes/Attribute/FakeAttributeCollection.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MolliePayments\Tests\Fakes\Attribute;
+
+use Kiener\MolliePayments\Struct\Attribute\AttributeCollection;
+
+class FakeAttributeCollection extends AttributeCollection
+{
+    public function getStructForFakeId(string $id): FakeAttributeStruct
+    {
+        if(!$this->has($id)) {
+            return new FakeAttributeStruct();
+        }
+
+        return $this->get($id);
+    }
+}

--- a/tests/PHPUnit/Fakes/Attribute/FakeAttributeStruct.php
+++ b/tests/PHPUnit/Fakes/Attribute/FakeAttributeStruct.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace MolliePayments\Tests\Fakes\Attribute;
+
+use Kiener\MolliePayments\Struct\Attribute\AttributeStruct;
+
+class FakeAttributeStruct extends AttributeStruct
+{
+    /**
+     * @var ?string
+     */
+    protected $string;
+
+    /**
+     * @var ?int
+     */
+    protected $int;
+
+    /**
+     * @var ?bool
+     */
+    protected $bool;
+
+    /**
+     * @var ?string
+     */
+    protected $camelCaseAttribute;
+
+    /**
+     * @var ?string
+     */
+    protected $snake_case_attribute;
+
+    /**
+     * @return string|null
+     */
+    public function getString(): ?string
+    {
+        return $this->string;
+    }
+
+    /**
+     * @param string|null $string
+     */
+    public function setString(?string $string): void
+    {
+        $this->string = $string;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getInt(): ?int
+    {
+        return $this->int;
+    }
+
+    /**
+     * @param int|null $int
+     */
+    public function setInt(?int $int): void
+    {
+        $this->int = $int;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getBool(): ?bool
+    {
+        return $this->bool;
+    }
+
+    /**
+     * @param bool|null $bool
+     */
+    public function setBool(?bool $bool): void
+    {
+        $this->bool = $bool;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCamelCaseAttribute(): ?string
+    {
+        return $this->camelCaseAttribute;
+    }
+
+    /**
+     * @param string|null $camelCaseAttribute
+     */
+    public function setCamelCaseAttribute(?string $camelCaseAttribute): void
+    {
+        $this->camelCaseAttribute = $camelCaseAttribute;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSnakeCaseAttribute(): ?string
+    {
+        return $this->snake_case_attribute;
+    }
+
+    /**
+     * @param string|null $snake_case_attribute
+     */
+    public function setSnakeCaseAttribute(?string $snake_case_attribute): void
+    {
+        $this->snake_case_attribute = $snake_case_attribute;
+    }
+}

--- a/tests/PHPUnit/Fakes/Attribute/FakeEntityAttributeStruct.php
+++ b/tests/PHPUnit/Fakes/Attribute/FakeEntityAttributeStruct.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace MolliePayments\Tests\Fakes\Attribute;
+
+use Kiener\MolliePayments\Struct\Attribute\EntityAttributeStruct;
+
+class FakeEntityAttributeStruct extends EntityAttributeStruct
+{
+    /**
+     * @var ?string
+     */
+    protected $string;
+
+    /**
+     * @var ?int
+     */
+    protected $int;
+
+    /**
+     * @var ?bool
+     */
+    protected $bool;
+
+    /**
+     * @var ?string
+     */
+    protected $camelCaseAttribute;
+
+    /**
+     * @var ?string
+     */
+    protected $snake_case_attribute;
+
+    /**
+     * @var ?FakeAttributeCollection
+     */
+    protected $collection;
+
+    /**
+     * @return string|null
+     */
+    public function getString(): ?string
+    {
+        return $this->string;
+    }
+
+    /**
+     * @param string|null $string
+     */
+    public function setString(?string $string): void
+    {
+        $this->string = $string;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getInt(): ?int
+    {
+        return $this->int;
+    }
+
+    /**
+     * @param int|null $int
+     */
+    public function setInt(?int $int): void
+    {
+        $this->int = $int;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getBool(): ?bool
+    {
+        return $this->bool;
+    }
+
+    /**
+     * @param bool|null $bool
+     */
+    public function setBool(?bool $bool): void
+    {
+        $this->bool = $bool;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCamelCaseAttribute(): ?string
+    {
+        return $this->camelCaseAttribute;
+    }
+
+    /**
+     * @param string|null $camelCaseAttribute
+     */
+    public function setCamelCaseAttribute(?string $camelCaseAttribute): void
+    {
+        $this->camelCaseAttribute = $camelCaseAttribute;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSnakeCaseAttribute(): ?string
+    {
+        return $this->snake_case_attribute;
+    }
+
+    /**
+     * @param string|null $snake_case_attribute
+     */
+    public function setSnakeCaseAttribute(?string $snake_case_attribute): void
+    {
+        $this->snake_case_attribute = $snake_case_attribute;
+    }
+
+    /**
+     * @return FakeAttributeCollection|null
+     */
+    public function getCollection(): ?FakeAttributeCollection
+    {
+        return $this->collection;
+    }
+
+    /**
+     * @param array $values
+     * @throws \Exception
+     */
+    protected function constructCollection(array $values): void
+    {
+        $this->collection = new FakeAttributeCollection();
+        foreach($values as $key => $value) {
+            $struct = new FakeAttributeStruct($value);
+            $this->collection->set($key, $struct);
+        }
+    }
+}

--- a/tests/PHPUnit/Fakes/FakeEntity.php
+++ b/tests/PHPUnit/Fakes/FakeEntity.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MolliePayments\Tests\Fakes;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class FakeEntity extends Entity
+{
+    use EntityIdTrait;
+    use EntityCustomFieldsTrait;
+
+    public function __construct()
+    {
+        $this->setId(Uuid::randomHex());
+    }
+}

--- a/tests/PHPUnit/Fakes/FakeEntityWithoutCustomFields.php
+++ b/tests/PHPUnit/Fakes/FakeEntityWithoutCustomFields.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MolliePayments\Tests\Fakes;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class FakeEntityWithoutCustomFields extends Entity
+{
+    use EntityIdTrait;
+
+    public function __construct()
+    {
+        $this->setId(Uuid::randomHex());
+    }
+}

--- a/tests/PHPUnit/Struct/Attribute/AttributeStructTest.php
+++ b/tests/PHPUnit/Struct/Attribute/AttributeStructTest.php
@@ -1,0 +1,153 @@
+<?php declare(strict_types=1);
+
+namespace MolliePayments\Tests\Struct\Attribute;
+
+use MolliePayments\Tests\Fakes\Attribute\FakeAttributeStruct;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Struct\ArrayStruct;
+
+class AttributeStructTest extends TestCase
+{
+    public function testAttributesAreSetCorrectly()
+    {
+        $existingData = [
+            'string' => 'foo',
+            'int' => 123,
+            'bool' => true,
+        ];
+
+        $struct = new FakeAttributeStruct($existingData);
+
+        $this->assertEquals($existingData['string'], $struct->getString());
+        $this->assertEquals($existingData['int'], $struct->getInt());
+        $this->assertEquals($existingData['bool'], $struct->getBool());
+        $this->assertEquals(null, $struct->getCamelCaseAttribute());
+        $this->assertEquals(null, $struct->getSnakeCaseAttribute());
+    }
+
+    /**
+     * Tests whether getVars/toArray converts the struct properties back to their original array.
+     */
+    public function testAttributesAreConvertingBackToArray()
+    {
+        $existingData = [
+            'string' => 'foo',
+            'int' => 123,
+            'bool' => true,
+            'camelCaseAttribute' => 'bar',
+            'snake_case_attribute' => 'baz',
+        ];
+
+        $struct = new FakeAttributeStruct($existingData);
+
+        $this->assertEquals($existingData, $struct->getVars());
+        $this->assertEquals($existingData, $struct->toArray());
+    }
+
+    public function testNulledAttributesAreAddedToArray()
+    {
+        $existingData = [
+            'string' => 'foo',
+            'int' => 123,
+            'bool' => true,
+        ];
+
+        $struct = new FakeAttributeStruct($existingData);
+        $struct->setString(null);
+
+        $expectedData = [
+            'string' => null,
+            'int' => 123,
+            'bool' => true,
+        ];
+
+        $this->assertEquals($expectedData, $struct->getVars());
+        $this->assertEquals($expectedData, $struct->toArray());
+
+        $this->assertNotEquals($existingData, $struct->getVars());
+        $this->assertNotEquals($existingData, $struct->toArray());
+    }
+
+    public function testNewlySetAttributesAreAddedToArray()
+    {
+        $existingData = [
+            'string' => 'foo',
+            'int' => 123,
+        ];
+
+        $struct = new FakeAttributeStruct($existingData);
+        $struct->setBool(false);
+
+        $expectedData = [
+            'string' => 'foo',
+            'int' => 123,
+            'bool' => false,
+        ];
+
+        $this->assertEquals($expectedData, $struct->getVars());
+        $this->assertEquals($expectedData, $struct->toArray());
+
+        $this->assertNotEquals($existingData, $struct->getVars());
+        $this->assertNotEquals($existingData, $struct->toArray());
+    }
+
+    public function testDifferentCaseAttributesAreSet()
+    {
+        $existingData = [
+            'camelCaseAttribute' => 'foo',
+            'snake_case_attribute' => 'bar',
+        ];
+
+        $struct = new FakeAttributeStruct($existingData);
+
+        $this->assertEquals('foo', $struct->getCamelCaseAttribute());
+        $this->assertEquals('bar', $struct->getSnakeCaseAttribute());
+    }
+
+    public function testMergeTwoStructs()
+    {
+        $data1 = [
+            'string' => 'foo',
+            'int' => 123,
+        ];
+
+        $data2 = [
+            'camelCaseAttribute' => 'foo',
+            'snake_case_attribute' => 'bar',
+        ];
+
+        $struct1 = new FakeAttributeStruct($data1);
+        $struct2 = new FakeAttributeStruct($data2);
+
+        $struct1->merge($struct2);
+
+        $expectedData = [
+            'string' => 'foo',
+            'int' => 123,
+            'camelCaseAttribute' => 'foo',
+            'snake_case_attribute' => 'bar',
+        ];
+
+        $this->assertNotEquals($data1, $struct1->getVars());
+        $this->assertEquals($expectedData, $struct1->getVars());
+    }
+
+    public function testNonPropertiesAreStoredInExtension()
+    {
+        $existingData = [
+            'thisPropertyDoesNotExist' => true,
+        ];
+
+        $struct = new FakeAttributeStruct($existingData);
+
+        $this->assertInstanceOf(ArrayStruct::class, $struct->getExtension($struct::ADDITIONAL));
+
+        /** @var ArrayStruct $additional */
+        $additional = $struct->getExtension($struct::ADDITIONAL);
+
+        $this->assertTrue($additional->has('thisPropertyDoesNotExist'));
+        $this->assertEquals(true, $additional->get('thisPropertyDoesNotExist'));
+
+        $this->assertEquals($existingData, $struct->getVars());
+    }
+}

--- a/tests/PHPUnit/Struct/Attribute/EntityAttributeStructTest.php
+++ b/tests/PHPUnit/Struct/Attribute/EntityAttributeStructTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace MolliePayments\Tests\Struct\Attribute;
+
+use Kiener\MolliePayments\Service\CustomFieldsInterface;
+use Kiener\MolliePayments\Struct\Attribute\AttributeCollection;
+use Kiener\MolliePayments\Struct\Attribute\AttributeStruct;
+use MolliePayments\Tests\Fakes\Attribute\FakeAttributeCollection;
+use MolliePayments\Tests\Fakes\Attribute\FakeEntityAttributeStruct;
+use MolliePayments\Tests\Fakes\FakeEntity;
+use MolliePayments\Tests\Fakes\FakeEntityWithoutCustomFields;
+use PHPUnit\Framework\TestCase;
+
+class EntityAttributeStructTest extends TestCase
+{
+    public function testExceptionIsThrownIfEntityDoesNotSupportCustomFields()
+    {
+        $this->expectException(\Exception::class);
+
+        new FakeEntityAttributeStruct(new FakeEntityWithoutCustomFields());
+    }
+
+    public function testAttributesAreEmptyWithNoCustomFields()
+    {
+        $entity1 = new FakeEntity();
+
+        $attr1 = new FakeEntityAttributeStruct($entity1);
+        $this->assertEquals([], $attr1->getVars());
+
+        //===============================================//
+
+        $entity2 = new FakeEntity();
+        $entity2->setCustomFields([
+            'foo' => 'bar'
+        ]);
+
+        $attr2 = new FakeEntityAttributeStruct($entity2);
+        $this->assertEquals([], $attr2->getVars());
+    }
+
+    public function testMollieAttributesAreSet()
+    {
+        $entity = new FakeEntity();
+        $entity->setCustomFields([
+            CustomFieldsInterface::MOLLIE_KEY => [
+                'string' => 'foo',
+                'int' => 123,
+                'bool' => true
+            ]
+        ]);
+
+        $attr = new FakeEntityAttributeStruct($entity);
+
+        $this->assertEquals('foo', $attr->getString());
+        $this->assertEquals(123, $attr->getInt());
+        $this->assertEquals(true, $attr->getBool());
+    }
+
+    public function testTranslatedEntity()
+    {
+        $entity = new FakeEntity();
+        $entity->setCustomFields([
+            CustomFieldsInterface::MOLLIE_KEY => [
+                'string' => 'bar',
+                'int' => 123,
+                'bool' => true
+            ]
+        ]);
+        $entity->setTranslated([
+            'customFields' => [
+                CustomFieldsInterface::MOLLIE_KEY => [
+                    'string' => 'bar',
+                    'int' => 123,
+                    'bool' => true,
+                    'camelCaseAttribute' => 'camel',
+                    'snake_case_attribute' => 'snake'
+                ]
+            ]
+        ]);
+
+        $attr = new FakeEntityAttributeStruct($entity);
+
+        $this->assertEquals('camel', $attr->getCamelCaseAttribute());
+        $this->assertEquals('snake', $attr->getSnakeCaseAttribute());
+    }
+
+    public function testEntityWithCollectionInCustomFields()
+    {
+        $entity = new FakeEntity();
+        $entity->setCustomFields([
+            CustomFieldsInterface::MOLLIE_KEY => [
+                'collection' => [
+                    'foo' => [
+                        'string' => 'foo',
+                        'int' => 123,
+                    ],
+                    'bar' => [
+                        'bool' => false,
+                        'camelCaseAttribute' => 'camel'
+                    ]
+                ]
+            ]
+        ]);
+
+        $attr = new FakeEntityAttributeStruct($entity);
+
+        $this->assertInstanceOf(AttributeCollection::class, $attr->getCollection());
+
+        /** @var FakeAttributeCollection $collection */
+        $collection = $attr->getCollection();
+
+        $this->assertTrue($collection->has('foo'));
+        $this->assertTrue($collection->has('bar'));
+
+        $this->assertInstanceOf(AttributeStruct::class, $collection->getStructForFakeId('foo'));
+        $this->assertInstanceOf(AttributeStruct::class, $collection->getStructForFakeId('bar'));
+
+        $foo = $collection->getStructForFakeId('foo');
+        $this->assertEquals('foo', $foo->getString());
+        $this->assertEquals(123, $foo->getInt());
+        $this->assertEquals(null, $foo->getBool());
+
+        $bar = $collection->getStructForFakeId('bar');
+        $this->assertEquals(null, $bar->getString());
+        $this->assertEquals(false, $bar->getBool());
+        $this->assertEquals('camel', $bar->getCamelCaseAttribute());
+    }
+
+    public function testConvertToMollieArray()
+    {
+        $customFields = [
+            CustomFieldsInterface::MOLLIE_KEY => [
+                'string' => 'bar',
+                'int' => 123,
+                'bool' => true,
+                'camelCaseAttribute' => 'camel',
+                'snake_case_attribute' => 'snake',
+                'collection' => [
+                    'foo' => [
+                        'string' => 'foo',
+                        'int' => 123,
+                    ],
+                    'bar' => [
+                        'bool' => false,
+                        'camelCaseAttribute' => 'camel'
+                    ]
+                ]
+            ]
+        ];
+
+        $entity = new FakeEntity();
+        $entity->setCustomFields($customFields);
+
+        $attr = new FakeEntityAttributeStruct($entity);
+
+        $this->assertEquals($customFields, $attr->toMollieCustomFields());
+    }
+}


### PR DESCRIPTION
@boxblinkracer mentioned in a taskforce meeting about wanting to approach custom fields in an Object Oriented way.
Currently, there are several CustomFields/Attribute classes that all do their own thing and don't inherit any functionality from a single base class. They also all set the initial properties in their own way.

This PR hopes to add a base for OO custom fields. Similar to regular Shopware Entities, your attribute class extends the base `EntityAttributeStruct` and only contains properties and get/set methods that should be available in the custom fields array. No separate constructors required for each attribute class. 
If a property requires a special initial setup, for example, converting an array with objects to an AttributeCollection with AttributeStructs, then a `constructPropertyName` method can be created which is only available when the EntityAttributeStruct is initially construct.
The EntityAttributeStruct also handles translatable entities by grabbing the custom fields from getTranslated, if available.

**Example usage:**

Create a class that extends EntityAttributeStruct
```
class PaymentMethodAttributeStruct extends EntityAttributeStruct
{
    protected $name;
    
    public function getName(): string
    {
        return $this->name;    
    }
    
    public function setName($name): void
    {
        $this->name = $name;
    }
}
```

Create the attribute struct by passing an Entity into its constructor
`$attributes = new PaymentMethodAttributeStruct($paymentMethodEntity);`

Revert the attribute struct back to an array for storage.
```
$array = $attributes->toMollieCustomFields();

//    [
//        'mollie_payments' => [
//            'name' => 'ideal'
//        ]
//    ]
```

