### PR TITLE
MOL-623: Change selector for confirm button

### DIFF
--- a/src/Resources/app/storefront/src/mollie-payments/plugins/creditcard-components-sw64.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/creditcard-components-sw64.plugin.js
@@ -88,7 +88,7 @@ export default class MollieCreditCardComponentsSw64 extends Plugin {
             mollieController: 'div.mollie-components-controller',
             paymentForm: '#changePaymentForm',
             confirmForm: '#confirmOrderForm',
-            confirmFormButton: '#confirmFormSubmit',
+            confirmFormButton: '#confirmOrderForm > button[type="submit"]',
         };
     }
 

--- a/tests/Cypress/cypress/integration/storefront/payment-methods/creditcard.spec.js
+++ b/tests/Cypress/cypress/integration/storefront/payment-methods/creditcard.spec.js
@@ -158,7 +158,7 @@ describe('Credit Card Components', () => {
                 assertComponentErrors(true, true, true, false);
             })
 
-            it('Components are initialized after failed payment', () => {
+            it('Complete payment after failure with components', () => {
                 // We need to test this with Shopware's complete order page.
                 configAction.setupShop(false, true, false);
 

--- a/tests/Cypress/cypress/integration/storefront/payment-methods/creditcard.spec.js
+++ b/tests/Cypress/cypress/integration/storefront/payment-methods/creditcard.spec.js
@@ -177,12 +177,7 @@ describe('Credit Card Components', () => {
 
                 cy.url().should('include', 'https://www.mollie.com/checkout/');
 
-                // verify that our component card is really
-                // been used by comparing the last 4 digits
-                cy.contains('**** ' + validCardNumber.substr(validCardNumber.length - 4));
-
                 molliePayment.initSandboxCookie();
-
                 molliePayment.selectFailed();
 
                 cy.url().should('include', '/account/order/edit');

--- a/tests/Cypress/cypress/integration/storefront/payment-methods/creditcard.spec.js
+++ b/tests/Cypress/cypress/integration/storefront/payment-methods/creditcard.spec.js
@@ -157,6 +157,53 @@ describe('Credit Card Components', () => {
 
                 assertComponentErrors(true, true, true, false);
             })
+
+            it('Components are initialized after failed payment', () => {
+                // We need to test this with Shopware's complete order page.
+                configAction.setupShop(false, true, false);
+
+                setUp();
+
+                payment.fillCreditCardComponents('Mollie Tester', validCardNumber, '1228', '1234');
+
+                // we are still in our modal, so we
+                // have to close it in older versions
+                if (shopware.isVersionLower(6.4)) {
+                    payment.closePaymentsModal();
+                }
+
+                shopware.prepareDomainChange();
+                checkout.placeOrderOnConfirm();
+
+                cy.url().should('include', 'https://www.mollie.com/checkout/');
+
+                // verify that our component card is really
+                // been used by comparing the last 4 digits
+                cy.contains('**** ' + validCardNumber.substr(validCardNumber.length - 4));
+
+                molliePayment.initSandboxCookie();
+
+                molliePayment.selectFailed();
+
+                cy.url().should('include', '/account/order/edit');
+                cy.contains('Complete payment');
+
+                // If components are not initialized, Cypress can't find the inputs and will error.
+                payment.fillCreditCardComponents('Mollie Tester', validCardNumber, '1228', '1234');
+
+                // we are still in our modal, so we
+                // have to close it in older versions
+                if (shopware.isVersionLower(6.4)) {
+                    payment.closePaymentsModal();
+                }
+
+                checkout.placeOrderOnEdit();
+
+                // Apparently we are not being sent to Mollie if we failed the first time and enter the same credentials again.
+                // It just immediately redirects to checkout/finish. Probably a bug in Shopware
+                cy.url().should('include', '/checkout/finish');
+                cy.contains('Thank you for updating your order');
+            })
         })
     })
 })


### PR DESCRIPTION
The account order edit page does not have an id attribute on it's submit button, so the components would not get initialized.