### PR TITLE
NTR: Add transaction id to custom fields

### DIFF
--- a/src/Facade/MolliePaymentFinalize.php
+++ b/src/Facade/MolliePaymentFinalize.php
@@ -86,8 +86,8 @@ class MolliePaymentFinalize
 
         // Add the transaction ID to the order's custom fields
         // We might need this later on for reconciliation
-        $mollieTransactionId = $mollieOrder->_embedded->payments[0]->id;
-        $customFieldsStruct->setMollieTransactionId($mollieTransactionId);
+        $molliePaymentId = $mollieOrder->_embedded->payments[0]->id;
+        $customFieldsStruct->setMolliePaymentId($molliePaymentId);
         $this->updateOrderCustomFields->updateOrder($order->getId(), $customFieldsStruct, $salesChannelContext);
 
         $settings = $this->settingsService->getSettings($salesChannelContext->getSalesChannel()->getId());

--- a/src/Resources/config/services/facades.xml
+++ b/src/Resources/config/services/facades.xml
@@ -34,6 +34,7 @@
             <argument type="service" id="Kiener\MolliePayments\Service\Mollie\OrderStatusConverter"/>
             <argument type="service" id="Kiener\MolliePayments\Service\Order\OrderStatusUpdater"/>
             <argument type="service" id="Kiener\MolliePayments\Service\SettingsService"/>
+            <argument type="service" id="Kiener\MolliePayments\Service\UpdateOrderCustomFields"/>
         </service>
 
         <service id="Kiener\MolliePayments\Facade\MollieOrderPaymentFlow">

--- a/src/Struct/MollieOrderCustomFieldsStruct.php
+++ b/src/Struct/MollieOrderCustomFieldsStruct.php
@@ -8,7 +8,7 @@ class MollieOrderCustomFieldsStruct
     private $mollieOrderId;
 
     /** @var string|null */
-    private $mollieTransactionId;
+    private $molliePaymentId;
 
     /** @var string|null */
     private $transactionReturnUrl;
@@ -45,17 +45,17 @@ class MollieOrderCustomFieldsStruct
     /**
      * @return string|null
      */
-    public function getMollieTransactionId(): ?string
+    public function getMolliePaymentId(): ?string
     {
-        return $this->mollieTransactionId;
+        return $this->molliePaymentId;
     }
 
     /**
-     * @param string|null $mollieTransactionId
+     * @param string|null $molliePaymentId
      */
-    public function setMollieTransactionId(?string $mollieTransactionId): void
+    public function setMolliePaymentId(?string $molliePaymentId): void
     {
-        $this->mollieTransactionId = $mollieTransactionId;
+        $this->molliePaymentId = $molliePaymentId;
     }
 
     /**
@@ -102,7 +102,7 @@ class MollieOrderCustomFieldsStruct
         return [
             'mollie_payments' => [
                 'order_id' => $this->mollieOrderId,
-                'transaction_id' => $this->mollieTransactionId,
+                'payment_id' => $this->molliePaymentId,
                 'transactionReturnUrl' => (string)$this->transactionReturnUrl,
                 'molliePaymentUrl' => (string)$this->molliePaymentUrl
             ]
@@ -122,8 +122,8 @@ class MollieOrderCustomFieldsStruct
             $this->setMollieOrderId((string)$customFields['mollie_payments']['order_id']);
         }
 
-        if (isset($customFields['mollie_payments']['transaction_id'])) {
-            $this->setMollieTransactionId((string)$customFields['mollie_payments']['transaction_id']);
+        if (isset($customFields['mollie_payments']['payment_id'])) {
+            $this->setMolliePaymentId((string)$customFields['mollie_payments']['payment_id']);
         }
 
         if (isset($customFields['mollie_payments']['transactionReturnUrl'])) {

--- a/src/Struct/MollieOrderCustomFieldsStruct.php
+++ b/src/Struct/MollieOrderCustomFieldsStruct.php
@@ -8,6 +8,9 @@ class MollieOrderCustomFieldsStruct
     private $mollieOrderId;
 
     /** @var string|null */
+    private $mollieTransactionId;
+
+    /** @var string|null */
     private $transactionReturnUrl;
 
     /** @var string|null */
@@ -37,6 +40,22 @@ class MollieOrderCustomFieldsStruct
     public function setMollieOrderId(?string $mollieOrderId): void
     {
         $this->mollieOrderId = $mollieOrderId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMollieTransactionId(): ?string
+    {
+        return $this->mollieTransactionId;
+    }
+
+    /**
+     * @param string|null $mollieTransactionId
+     */
+    public function setMollieTransactionId(?string $mollieTransactionId): void
+    {
+        $this->mollieTransactionId = $mollieTransactionId;
     }
 
     /**
@@ -83,6 +102,7 @@ class MollieOrderCustomFieldsStruct
         return [
             'mollie_payments' => [
                 'order_id' => $this->mollieOrderId,
+                'transaction_id' => $this->mollieTransactionId,
                 'transactionReturnUrl' => (string)$this->transactionReturnUrl,
                 'molliePaymentUrl' => (string)$this->molliePaymentUrl
             ]
@@ -100,6 +120,10 @@ class MollieOrderCustomFieldsStruct
 
         if (isset($customFields['mollie_payments']['order_id'])) {
             $this->setMollieOrderId((string)$customFields['mollie_payments']['order_id']);
+        }
+
+        if (isset($customFields['mollie_payments']['transaction_id'])) {
+            $this->setMollieTransactionId((string)$customFields['mollie_payments']['transaction_id']);
         }
 
         if (isset($customFields['mollie_payments']['transactionReturnUrl'])) {


### PR DESCRIPTION
As a merchant doing my payments reconciliation
I want the Mollie payment ID per shop order
because it is listed in the payout CSV reports.

A line in a Mollie settlement file might look like:

```csv
"2021-12-07 08:25:56",klarnapaylater,EUR,129.00,,cpt_fooacr,"Capture of Pay later. transaction on 06-12-2021 to Max Merchant GmbH. Original payment: tr_xfOoBK8e8P - 'Bestellung 10083'","Constantin Consumer",,,EUR,129.00,123456789.2112.03,
```

In the order's custom fields we only log the `ord_` ID, which isn't reported back during reconciliation.

The merchant might try to match outpayments and orders by the order number part of the description, which can work, but using the `tr_` ID might be easier.

PayPal adds their ID to the transaction instead of the order, so maybe it might be worth the while to also do that: https://github.com/shopwareLabs/SwagPayPal/blob/4543ae7896cee34275f8fac397ef52431f838f65/src/Checkout/Payment/Handler/AbstractPaymentHandler.php#L25-L40