### PR TITLE
Fix payment specific params not being added to payment on reattempt

### DIFF
--- a/src/Facade/MolliePaymentDoPay.php
+++ b/src/Facade/MolliePaymentDoPay.php
@@ -138,7 +138,19 @@ class MolliePaymentDoPay
                 ]
             );
 
-            $payment = $this->orderApiService->createOrReusePayment($mollieOrderId, $paymentMethod, $salesChannelContext);
+            $customer = $this->customerService->getCustomer(
+                $order->getOrderCustomer()->getCustomerId(),
+                $salesChannelContext->getContext()
+            );
+
+            $payment = $this->orderApiService->createOrReusePayment(
+                $mollieOrderId,
+                $paymentMethod,
+                $paymentHandler,
+                $order,
+                $customer,
+                $salesChannelContext
+            );
 
             // if direct payment return to success page
             if (MolliePaymentStatus::isApprovedStatus($payment->status) && empty($payment->getCheckoutUrl())) {

--- a/src/Facade/MolliePaymentDoPay.php
+++ b/src/Facade/MolliePaymentDoPay.php
@@ -138,10 +138,7 @@ class MolliePaymentDoPay
                 ]
             );
 
-            $customer = $this->customerService->getCustomer(
-                $order->getOrderCustomer()->getCustomerId(),
-                $salesChannelContext->getContext()
-            );
+            $customer = $this->extractor->extractCustomer($order, $salesChannelContext);
 
             $payment = $this->orderApiService->createOrReusePayment(
                 $mollieOrderId,
@@ -179,7 +176,7 @@ class MolliePaymentDoPay
 
             $this->createCustomerAtMollie($order, $salesChannelContext);
 
-        } catch (CouldNotCreateMollieCustomerException | CustomerCouldNotBeFoundException $e) {
+        } catch (CouldNotCreateMollieCustomerException|CustomerCouldNotBeFoundException $e) {
 
             # TODO do we really need to catch this? shouldnt it fail fast?
 

--- a/src/Handler/PaymentHandler.php
+++ b/src/Handler/PaymentHandler.php
@@ -66,8 +66,6 @@ class PaymentHandler implements AsynchronousPaymentHandlerInterface
      * @param OrderEntity $orderEntity
      * @param SalesChannelContext $salesChannelContext
      * @param CustomerEntity $customer
-     * @param LocaleEntity $locale
-     *
      * @return array
      */
     public function processPaymentMethodSpecificParameters(array $orderData, OrderEntity $orderEntity, SalesChannelContext $salesChannelContext, CustomerEntity $customer): array

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -45,7 +45,7 @@
             <argument type="service" id="customer.repository"/>
             <argument type="service" id="Kiener\MolliePayments\Service\MollieApi\Customer"/>
             <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="monolog.logger"/>
+            <argument type="service" id="mollie_payments.logger"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
             <argument type="service" id="salutation.repository"/>
             <argument type="service" id="Kiener\MolliePayments\Service\SettingsService"/>

--- a/src/Service/CustomerService.php
+++ b/src/Service/CustomerService.php
@@ -192,6 +192,11 @@ class CustomerService
         // Store the card token in the custom fields
         $customFields[CustomFieldService::CUSTOM_FIELDS_KEY_MOLLIE_PAYMENTS][self::CUSTOM_FIELDS_KEY_CREDIT_CARD_TOKEN] = $cardToken;
 
+        $this->logger->debug("Setting Credit Card Token", [
+            'customerId' => $customer->getId(),
+            'customFields' => $customFields,
+        ]);
+
         // Store the custom fields on the customer
         return $this->customerRepository->update([[
             'id' => $customer->getId(),

--- a/src/Service/MollieApi/Order.php
+++ b/src/Service/MollieApi/Order.php
@@ -255,7 +255,7 @@ class Order
         return $mollieOrder->createPayment($fakeOrder['payment']);
     }
 
-    public function getPaymentUrl(string $mollieOrderId, string $salesChannelId): ?string
+    public function getPaymentUrl(string $mollieOrderId, string $salesChannelId, Context $context): ?string
     {
         $mollieOrder = $this->getMollieOrder($mollieOrderId, $salesChannelId, $context);
 

--- a/src/Service/MollieApi/Order.php
+++ b/src/Service/MollieApi/Order.php
@@ -239,6 +239,9 @@ class Order
         SalesChannelContext $salesChannelContext
     ): Payment
     {
+        // To add payment method specific parameters to our payment data, the method requires an array named orderData
+        // We have no interest in order data, just the payment data that is inside it, but we still need to pass
+        // along an array with a key 'payment'. This is our fake order data array.
         $fakeOrder = [
             'payment' => [
                 'method' => $paymentMethod


### PR DESCRIPTION
Payment specific parameters were not passed along to Mollie when creating a new payment after the first one failed.