### PR TITLE
NTR: Quick disable shipping on delivery state change.

### DIFF
--- a/src/Subscriber/OrderDeliverySubscriber.php
+++ b/src/Subscriber/OrderDeliverySubscriber.php
@@ -26,7 +26,7 @@ class OrderDeliverySubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            'state_machine.order_delivery.state_changed' => 'onOrderDeliveryChanged',
+           // 'state_machine.order_delivery.state_changed' => 'onOrderDeliveryChanged',
         ];
     }
 


### PR DESCRIPTION
As discussed, I think there's a separate ticket for this to do it properly, this just disables the event.