### PR TITLE
MOL-719: Show existing trackingcodes and prefill tracking info

### DIFF
--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-tracking-info/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-tracking-info/index.js
@@ -1,12 +1,23 @@
 import template from './mollie-tracking-info.html.twig';
+import './mollie-tracking-info.scss';
 
 // eslint-disable-next-line no-undef
 const {Component} = Shopware;
+// eslint-disable-next-line no-undef
+const {string} = Shopware.Utils;
 
 Component.register('mollie-tracking-info', {
     template,
 
     props: {
+        delivery: {
+            type: Object,
+            required: true,
+            default() {
+                return null
+            },
+        },
+
         tracking: {
             type: Object,
             required: true,
@@ -17,6 +28,36 @@ Component.register('mollie-tracking-info', {
                     url: '',
                 }
             },
+        },
+    },
+
+    created() {
+        this.createdComponent();
+    },
+
+    methods: {
+        createdComponent() {
+            if(this.delivery.trackingCodes.length === 1) {
+                this.prefillTrackingInfo(this.delivery.trackingCodes[0], this.delivery.shippingMethod);
+            }
+        },
+
+        prefillTrackingInfo(trackingCode, shippingMethod) {
+            this.tracking.carrier = shippingMethod.name;
+            this.tracking.code = trackingCode;
+
+            if(!string.isEmptyOrSpaces(shippingMethod.trackingUrl)) {
+                this.tracking.url = this.renderTrackingUrl(trackingCode, shippingMethod);
+            }
+        },
+
+        /**
+         * Copied from src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js
+         */
+        renderTrackingUrl(trackingCode, shippingMethod) {
+            const urlTemplate = shippingMethod ? shippingMethod.trackingUrl : null;
+
+            return urlTemplate ? urlTemplate.replace('%s', encodeURIComponent(trackingCode)) : '';
         },
     },
 });

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-tracking-info/mollie-tracking-info.html.twig
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-tracking-info/mollie-tracking-info.html.twig
@@ -1,10 +1,34 @@
-<sw-container columns="1fr" justify="start">
-    <sw-text-field v-model="tracking.carrier"
-                   :label="$tc('mollie-payments.modals.shipping.tracking.carrier')"
-                   required />
-    <sw-text-field v-model="tracking.code"
-                   :label="$tc('mollie-payments.modals.shipping.tracking.code')"
-                   required />
-    <sw-text-field v-model="tracking.url"
-                   :label="$tc('mollie-payments.modals.shipping.tracking.url')" />
-</sw-container>
+{% block mollie_tracking_info %}
+    <sw-container>
+        <sw-base-field v-if="delivery.trackingCodes.length > 0"
+                       :label="$tc('mollie-payments.modals.shipping.availableTracking.label')">
+            <template #sw-field-input>
+                <sw-button
+                    v-for="trackingCode in delivery.trackingCodes"
+                    :key="trackingCode"
+                    class="mollie-tracking-info__tracking-code-button"
+                    size="x-small"
+                    @click="prefillTrackingInfo(trackingCode, delivery.shippingMethod)"
+                >{{ trackingCode }}</sw-button>
+            </template>
+
+            <template #hint>
+                {{ $tc('mollie-payments.modals.shipping.availableTracking.hint') }}
+            </template>
+        </sw-base-field>
+
+        <sw-container columns="1fr" justify="start" gap="16px">
+            <sw-text-field v-model="tracking.carrier"
+                           :label="$tc('mollie-payments.modals.shipping.tracking.carrier')"
+                           size="medium"
+                           required/>
+            <sw-text-field v-model="tracking.code"
+                           :label="$tc('mollie-payments.modals.shipping.tracking.code')"
+                           size="medium"
+                           required/>
+            <sw-text-field v-model="tracking.url"
+                           size="medium"
+                           :label="$tc('mollie-payments.modals.shipping.tracking.url')"/>
+        </sw-container>
+    </sw-container>
+{% endblock %}

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-tracking-info/mollie-tracking-info.scss
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-tracking-info/mollie-tracking-info.scss
@@ -1,0 +1,9 @@
+.mollie-tracking-info {
+    &__tracking-code-button {
+        margin-bottom: 0.25rem;
+
+        &:not(:last-child) {
+            margin-right: 0.25rem;
+        }
+    }
+}

--- a/src/Resources/app/administration/src/module/mollie-payments/extension/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/extension/sw-order/component/sw-order-line-items-grid/index.js
@@ -150,7 +150,11 @@ Component.override('sw-order-line-items-grid', {
 
     methods: {
         createdComponent() {
-            this.getShippingStatus();
+            // Do not attempt to load the shipping status if this isn't a Mollie order,
+            // or it will trigger an exception in the API.
+            if(this.isMollieOrder){
+                this.getShippingStatus();
+            }
         },
 
         //==== Refunds ==============================================================================================//

--- a/src/Resources/app/administration/src/module/mollie-payments/extension/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
+++ b/src/Resources/app/administration/src/module/mollie-payments/extension/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
@@ -51,8 +51,6 @@
                                     <sw-context-menu-item
                                             class="sw-order-line-items-grid__actions-refund-btn"
                                             icon="default-money-cash"
-                                            variant="ghost"
-                                            size="small"
                                             :disabled="!canOpenRefundModal"
                                             @click="onOpenRefundModal">
                                         {{ $tc('mollie-payments.general.refundThroughMollie') }}
@@ -166,19 +164,28 @@
               @modal-close="onCloseShipOrderModal"
               :title="$tc('mollie-payments.modals.shipping.title')"
               variant="small">
-        <p>{{ $tc('mollie-payments.modals.shipping.order.description') }}</p>
-        <sw-data-grid class="mollie-ship-order-grid"
-                      :dataSource="shippableLineItems"
-                      :columns="getShipOrderColumns"
-                      :plainAppearance="true"
-                      :showSelection="false"
-                      :showPreviews="false"
-                      :showActions="false"/>
+        <sw-container columns="1fr" gap="16px">
+            <p>{{ $tc('mollie-payments.modals.shipping.order.description') }}</p>
 
-        {% block sw_order_line_items_grid_grid_mollie_ship_item_modal_tracking %}
-            <sw-switch-field v-model="showTrackingInfo" :label="$tc('mollie-payments.modals.shipping.showTracking')"/>
-            <mollie-tracking-info v-if="showTrackingInfo" :tracking="tracking"/>
-        {% endblock %}
+            <sw-data-grid class="mollie-ship-order-grid"
+                          :dataSource="shippableLineItems"
+                          :columns="getShipOrderColumns"
+                          :plainAppearance="true"
+                          :showSelection="false"
+                          :showPreviews="false"
+                          :showActions="false"/>
+
+            {% block sw_order_line_items_grid_grid_mollie_ship_item_modal_tracking %}
+                <sw-switch-field v-model="showTrackingInfo"
+                                 :label="$tc('mollie-payments.modals.shipping.showTracking')"
+                                 :noMarginTop="true"
+                                 size="small"/>
+
+                <mollie-tracking-info v-if="showTrackingInfo"
+                                      :delivery="order.deliveries.first()"
+                                      :tracking="tracking"/>
+            {% endblock %}
+        </sw-container>
 
         <template #modal-footer>
             <sw-button @click="onCloseShipOrderModal" size="small">
@@ -213,9 +220,10 @@
                   @modal-close="onCloseShipItemModal"
                   :title="$tc('mollie-payments.modals.shipping.title')"
                   variant="small">
-            <template>
+
+            <sw-container columns="1fr" gap="16px">
                 {% block sw_order_line_items_grid_grid_mollie_ship_item_modal_product %}
-                    {{ $tc('mollie-payments.modals.shipping.item.label') }} <strong>{{ item.label }}</strong>
+                    <div>{{ $tc('mollie-payments.modals.shipping.item.label') }} <strong>{{ item.label }}</strong></div>
                 {% endblock %}
 
                 {% block sw_order_line_items_grid_grid_mollie_ship_item_modal_description %}
@@ -255,10 +263,16 @@
                 {% endblock %}
 
                 {% block sw_order_line_items_grid_grid_mollie_ship_item_modal_tracking %}
-                    <sw-switch-field v-model="showTrackingInfo" :label="$tc('mollie-payments.modals.shipping.showTracking')"/>
-                    <mollie-tracking-info v-if="showTrackingInfo" :tracking="tracking"/>
+                    <sw-switch-field v-model="showTrackingInfo"
+                                     :label="$tc('mollie-payments.modals.shipping.showTracking')"
+                                     :noMarginTop="true"
+                                     size="small"/>
+
+                    <mollie-tracking-info v-if="showTrackingInfo"
+                                          :delivery="order.deliveries.first()"
+                                          :tracking="tracking"/>
                 {% endblock %}
-            </template>
+            </sw-container>
 
             <template #modal-footer>
                 <sw-button @click="onCloseShipItemModal" size="small">

--- a/src/Resources/app/administration/src/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/snippet/de-DE.json
@@ -82,6 +82,10 @@
           "itemHeader": "Artikel",
           "quantityHeader": "Menge"
         },
+        "availableTracking": {
+          "label": "Verfügbare Tracking-Codes",
+          "hint": "Klicken Sie auf einen dieser Tracking-Codes, um alle Daten automatisch auszufüllen."
+        },
         "showTracking": "Tracking-Informationen für diese Sendung hinzufügen",
         "tracking": {
           "carrier": "Spediteur",

--- a/src/Resources/app/administration/src/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/snippet/en-GB.json
@@ -82,6 +82,10 @@
           "itemHeader": "Item",
           "quantityHeader": "Quantity"
         },
+        "availableTracking": {
+          "label": "Available tracking codes",
+          "hint": "Click one of these tracking codes to automatically fill in all data."
+        },
         "showTracking": "Add tracking info for this shipment",
         "tracking": {
           "carrier": "Carrier",

--- a/src/Resources/app/administration/src/snippet/nl-NL.json
+++ b/src/Resources/app/administration/src/snippet/nl-NL.json
@@ -82,6 +82,10 @@
           "itemHeader": "Product",
           "quantityHeader": "Aantal"
         },
+        "availableTracking": {
+          "label": "Beschikbare tracking codes",
+          "hint": "Klik op een van deze tracking codes om automatisch alle gegevens in te vullen."
+        },
         "showTracking": "Voeg tracking info toe aan deze zending",
         "tracking": {
           "carrier": "Carrier",


### PR DESCRIPTION
Tracking codes that are available on the order are shown as clickable buttons. Clicking one will automatically fill the tracking info fields.
If only one tracking code is available it is automatically prefilled.

Tracking url from the shipping method is used to generate the correct url. If it's not available on the shipping method, it remains empty. 

![image](https://user-images.githubusercontent.com/39724314/151371844-bbf283c9-28aa-434c-83bc-08c3e4fdb90a.png)
A google query has been used as example
