### PR TITLE
MOL-724: Replace JS Fetch Command in Apple Pay Direct for IE

### DIFF
--- a/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-direct.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-direct.plugin.js
@@ -51,41 +51,23 @@ export default class MollieApplePayDirect extends Plugin {
         // verify if apple pay is even allowed
         // in our current sales channel
 
-        // TODO Promises dont work in IE either
-        const applePayAvailablePromise = this.isApplePayAvailable(shopUrl);
+        me.client.get(
+            shopUrl + '/mollie/apple-pay/available',
+            data => {
+                if (data.available === undefined || data.available === false) {
+                    return;
+                }
 
-        applePayAvailablePromise.then(function (data) {
-
-            if (data.available === undefined || data.available === false) {
-                return;
+                applePayButtons.forEach(function (button) {
+                    // Remove display none
+                    button.classList.remove('d-none');
+                    // remove previous handlers (just in case)
+                    button.removeEventListener('click', me.onButtonClick.bind(me));
+                    // add click event handlers
+                    button.addEventListener('click', me.onButtonClick.bind(me));
+                });
             }
-
-            applePayButtons.forEach(function (button) {
-                // Remove display none
-                button.classList.remove('d-none');
-                // remove previous handlers (just in case)
-                button.removeEventListener('click', me.onButtonClick.bind(me));
-                // add click event handlers
-                button.addEventListener('click', me.onButtonClick.bind(me));
-            });
-        });
-    }
-
-
-    /**
-     *
-     * @param shopUrl
-     * @returns {Promise<unknown>}
-     */
-    isApplePayAvailable(shopUrl) {
-        const me = this;
-        return new Promise(function (resolve, reject) {
-            me.client.get(
-                shopUrl + '/mollie/apple-pay/available',
-                data => resolve(data),
-                () => reject()
-            );
-        });
+        );
     }
 
     /**

--- a/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-payment-method.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-payment-method.plugin.js
@@ -1,4 +1,5 @@
 import Plugin from 'src/plugin-system/plugin.class';
+import HttpClient from '../services/HttpClient';
 
 export default class MollieApplePayPaymentMethod extends Plugin {
 
@@ -25,11 +26,17 @@ export default class MollieApplePayPaymentMethod extends Plugin {
         // support for >= Shopware 6.4
         // we have to find the dynamic ID and use that
         // one as a selector to hide it
-        fetch(shopUrl + '/mollie/apple-pay/applepay-id')
-            .then(response => response.json())
-            .then(function (data) {
+        const client = new HttpClient();
+        client.get(
+            shopUrl + '/mollie/apple-pay/applepay-id',
+            (data) => {
                 me.hideApplePay('#paymentMethod' + data.id);
-            });
+            },
+            () => {
+            }
+        );
+
+
     }
 
     /**

--- a/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-payment-method.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-payment-method.plugin.js
@@ -31,8 +31,6 @@ export default class MollieApplePayPaymentMethod extends Plugin {
             shopUrl + '/mollie/apple-pay/applepay-id',
             (data) => {
                 me.hideApplePay('#paymentMethod' + data.id);
-            },
-            () => {
             }
         );
 

--- a/src/Resources/app/storefront/src/mollie-payments/plugins/creditcard-components-sw64.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/creditcard-components-sw64.plugin.js
@@ -1,6 +1,6 @@
 import Plugin from 'src/plugin-system/plugin.class';
 import DomAccess from 'src/helper/dom-access.helper';
-import HttpClient from '../services/HttpClient'
+import HttpClient from '../services/HttpClient';
 import DeviceDetection from 'src/helper/device-detection.helper';
 
 

--- a/src/Resources/app/storefront/src/mollie-payments/plugins/creditcard-components.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/creditcard-components.plugin.js
@@ -199,6 +199,7 @@ export default class MollieCreditCardComponents extends Plugin {
 
     async submitForm(event, componentsObject, paymentForm) {
         event.preventDefault();
+        const me = this;
         this.disableForm();
 
         const creditCardRadioInput = document.querySelector(this.getSelectors().creditCardRadioInput);
@@ -232,25 +233,21 @@ export default class MollieCreditCardComponents extends Plugin {
             }
 
             if (!error) {
-
                 // now we finish by first calling our URL to store
                 // the credit card token for the user and the current checkout
                 // and then we continue by submitting our original payment form.
-                const xhr = new XMLHttpRequest();
-                xhr.open('GET', this.options.shopUrl + '/mollie/components/store-card-token/' + this.options.customerId + '/' + token);
-                xhr.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
-
-                xhr.onload = function () {
-                    const tokenInput = document.getElementById('cardToken');
-                    tokenInput.setAttribute('value', token);
-                    paymentForm.submit();
-                };
-
-                xhr.onerror = function () {
-                    paymentForm.submit();
-                };
-
-                xhr.send();
+                this.client.get(
+                    me.options.shopUrl + '/mollie/components/store-card-token/' + me.options.customerId + '/' + token,
+                    () => {
+                        const tokenInput = document.getElementById('cardToken');
+                        tokenInput.setAttribute('value', token);
+                        paymentForm.submit();
+                    },
+                    () => {
+                        paymentForm.submit();
+                    },
+                    'application/json; charset=utf-8'
+                );
             }
         }
     }

--- a/src/Resources/app/storefront/src/mollie-payments/services/HttpClient.js
+++ b/src/Resources/app/storefront/src/mollie-payments/services/HttpClient.js
@@ -8,7 +8,7 @@ export default class HttpClient {
      * @param {function} callbackError
      * @param {string} contentType
      */
-    get(url, callbackSuccess, callbackError, contentType = DEFAULT_CONTENT_TYPE) {
+    get(url, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE) {
         this.send('GET', url, null, callbackSuccess, callbackError, contentType);
     }
 
@@ -20,7 +20,7 @@ export default class HttpClient {
      * @param {function} callbackError
      * @param {string} contentType
      */
-    post(url, data, callbackSuccess, callbackError, contentType = DEFAULT_CONTENT_TYPE) {
+    post(url, data, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE) {
         this.send('POST', url, data, callbackSuccess, callbackError, contentType);
     }
 
@@ -33,13 +33,17 @@ export default class HttpClient {
      * @param {function} callbackError
      * @param {string} contentType
      */
-    send(type, url, data, callbackSuccess, callbackError, contentType = DEFAULT_CONTENT_TYPE)
+    send(type, url, data, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE)
     {
         const xhr = new XMLHttpRequest();
         xhr.open(type, url);
         xhr.setRequestHeader('Content-Type', contentType);
 
         xhr.onload = function () {
+            if(!callbackSuccess || typeof callbackSuccess !== 'function') {
+                return;
+            }
+
             const responseType = xhr.getResponseHeader('content-type');
             const body = 'response' in xhr ? xhr.response : xhr.responseText
 
@@ -51,6 +55,10 @@ export default class HttpClient {
         };
 
         xhr.onerror = function () {
+            if(!callbackError || typeof callbackSuccess !== 'function') {
+                return;
+            }
+
             callbackError();
         };
 

--- a/src/Resources/app/storefront/src/mollie-payments/services/HttpClient.js
+++ b/src/Resources/app/storefront/src/mollie-payments/services/HttpClient.js
@@ -20,7 +20,7 @@ export default class HttpClient {
      * @param {function} callbackError
      * @param {string} contentType
      */
-    post(url, data, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE) {
+    post(url, data = null, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE) {
         this.send('POST', url, data, callbackSuccess, callbackError, contentType);
     }
 
@@ -33,7 +33,7 @@ export default class HttpClient {
      * @param {function} callbackError
      * @param {string} contentType
      */
-    send(type, url, data, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE)
+    send(type, url, data = null, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE)
     {
         const xhr = new XMLHttpRequest();
         xhr.open(type, url);

--- a/src/Resources/app/storefront/src/mollie-payments/services/HttpClient.js
+++ b/src/Resources/app/storefront/src/mollie-payments/services/HttpClient.js
@@ -1,36 +1,59 @@
 const DEFAULT_CONTENT_TYPE = 'application/json';
 
 export default class HttpClient {
-
-    /**
-     * Constructor.
-     */
-    constructor() {
-        this.request = null;
-    }
-
     /**
      * Request GET
      * @param {string} url
      * @param {function} callbackSuccess
      * @param {function} callbackError
      * @param {string} contentType
-     * @returns {XMLHttpRequest}
      */
     get(url, callbackSuccess, callbackError, contentType = DEFAULT_CONTENT_TYPE) {
-        const xhr = new XMLHttpRequest();
-        xhr.open('GET', url);
-        xhr.setRequestHeader('Content-Type', contentType);
-
-        xhr.onload = function (response) {
-            callbackSuccess(response);
-        };
-
-        xhr.onerror = function (response) {
-            callbackError(response);
-        };
-
-        xhr.send();
+        this.send('GET', url, null, callbackSuccess, callbackError, contentType);
     }
 
+    /**
+     * Request POST
+     * @param {string} url
+     * @param {*} data
+     * @param {function} callbackSuccess
+     * @param {function} callbackError
+     * @param {string} contentType
+     */
+    post(url, data, callbackSuccess, callbackError, contentType = DEFAULT_CONTENT_TYPE) {
+        this.send('POST', url, data, callbackSuccess, callbackError, contentType);
+    }
+
+    /**
+     * Sends an XMLHttpRequest
+     * @param {string} type
+     * @param {string} url
+     * @param {*} data
+     * @param {function} callbackSuccess
+     * @param {function} callbackError
+     * @param {string} contentType
+     */
+    send(type, url, data, callbackSuccess, callbackError, contentType = DEFAULT_CONTENT_TYPE)
+    {
+        const xhr = new XMLHttpRequest();
+        xhr.open(type, url);
+        xhr.setRequestHeader('Content-Type', contentType);
+
+        xhr.onload = function () {
+            const responseType = xhr.getResponseHeader('content-type');
+            const body = 'response' in xhr ? xhr.response : xhr.responseText
+
+            if(responseType.indexOf('application/json') > -1) {
+                callbackSuccess(JSON.parse(body));
+            } else {
+                callbackSuccess(body);
+            }
+        };
+
+        xhr.onerror = function () {
+            callbackError();
+        };
+
+        xhr.send(data);
+    }
 }


### PR DESCRIPTION
HttpClient has been updated to also allow POST. 
If the response is application/json it will auto parse it and return the parsed json object, otherwise it will just return the response body as is.
Callback functions are optional now.

All fetch statements have been removed from the Apple Pay JS plugins. 
The only other Promise in the Apple Pay Direct plugin has also been removed as IE also doesn't support those.