### PR TITLE
MOL-742: Fix JS Plugin DOM binding for Shopware 6.4.8.0

### DIFF
--- a/src/Resources/app/storefront/src/main.js
+++ b/src/Resources/app/storefront/src/main.js
@@ -10,12 +10,24 @@ import MollieApplePayPaymentMethod from './mollie-payments/plugins/apple-pay-pay
 
 // Register them via the existing PluginManager
 const PluginManager = window.PluginManager;
-PluginManager.register('MollieIDealIssuer', MollieIDealIssuer);
+
+
+// global plugins
+// -----------------------------------------------------------------------------
+// hide apple pay direct buttons across the whole shop, if not available
 PluginManager.register('MollieApplePayDirect', MollieApplePayDirect);
-PluginManager.register('MollieApplePayPaymentMethod', MollieApplePayPaymentMethod, '#mollie_hide_applepay');
+// this is just the iDEAL dropdown..not quite sure why its not bound to the DOM -> TODO?
+PluginManager.register('MollieIDealIssuer', MollieIDealIssuer);
 
-// < Sw 6.4 Version
-PluginManager.register('MollieCreditCardComponents', MollieCreditCardComponents, '#mollie_components_credit_card');
 
-// >= Sw 6.4 Version
-PluginManager.register('MollieCreditCardComponentsSw64', MollieCreditCardComponentsSw64, '#mollie_components_credit_card_sw64');
+// hiding the standard apple pay method in the checkout and account area
+// -----------------------------------------------------------------------------
+PluginManager.register('MollieApplePayPaymentMethod', MollieApplePayPaymentMethod, '[data-mollie-template-applepay-account]');
+PluginManager.register('MollieApplePayPaymentMethod', MollieApplePayPaymentMethod, '[data-mollie-template-applepay-checkout]');
+
+
+// showing credit card components in the checkout
+// we have 2 versions for < Shopware 6.4 and >= Shopware 6.4
+// -----------------------------------------------------------------------------
+PluginManager.register('MollieCreditCardComponents', MollieCreditCardComponents, '[data-mollie-template-creditcard-components]');
+PluginManager.register('MollieCreditCardComponentsSw64', MollieCreditCardComponentsSw64, '[data-mollie-template-creditcard-components-sw64]');

--- a/src/Resources/views/storefront/component/payment/component/cc-fields.html.twig
+++ b/src/Resources/views/storefront/component/payment/component/cc-fields.html.twig
@@ -1,5 +1,6 @@
 <div id="mollie_components_credit_card{% if sw64 %}_sw64{% endif %}"
      class="mollie-components-credit-card{% if not showIfActive %} d-none{% endif %}"
+      data-mollie-template-creditcard-components{% if sw64 %}-sw64{% endif %}
         {% if page.enable_credit_card_components == true %}
     data-mollie-credit-card-components-{% if sw64 %}sw64-{% endif %}options='{
         "customerId": "{{ context.customer.id }}",

--- a/src/Resources/views/storefront/page/account/payment/index.html.twig
+++ b/src/Resources/views/storefront/page/account/payment/index.html.twig
@@ -1,7 +1,7 @@
 {% sw_extends '@Storefront/storefront/page/account/payment/index.html.twig' %}
 
 {% block page_account_payment %}
-    <div id="mollie_hide_applepay" data-mollie-apple-pay-payment-method-options="{{ {
+    <div id="mollie_hide_applepay" data-mollie-template-applepay-account data-mollie-apple-pay-payment-method-options="{{ {
         shopUrl: seoUrl('frontend.home.page'),
         hideAlways: true
     }

--- a/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -1,7 +1,7 @@
 {% sw_extends '@Storefront/storefront/page/checkout/confirm/index.html.twig' %}
 
 {% block page_checkout_main_content %}
-    <div id="mollie_hide_applepay" data-mollie-apple-pay-payment-method-options="{{ {
+    <div id="mollie_hide_applepay" data-mollie-template-applepay-checkout data-mollie-apple-pay-payment-method-options="{{ {
         shopUrl: seoUrl('frontend.home.page'),
         hideAlways: false
     }


### PR DESCRIPTION
since Shopware 6.4.8.0 there is a console error on all pages.

the plugin did recently use IDs to bind the js plugins to the DOM
this however leads to an error in Shopware >= 6.4.8.0

so i've changed it to use data attributes