### PR TITLE
MOL-746: JS error with iDeal issuers

### DIFF
--- a/src/Resources/app/storefront/src/mollie-payments/plugins/ideal-issuer.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/ideal-issuer.plugin.js
@@ -39,6 +39,11 @@ export default class MollieIDealIssuer extends Plugin {
             return;
         }
 
+        // if we dont have the issuers dropdown available, then we can't even do anything
+        if (this._issuersDropdown === null) {
+            return;
+        }
+
         this.registerEvents();
 
         // update the visibility of our

--- a/src/Subscriber/SystemConfigSubscriber.php
+++ b/src/Subscriber/SystemConfigSubscriber.php
@@ -6,6 +6,7 @@ use Kiener\MolliePayments\Helper\ProfileHelper;
 use Kiener\MolliePayments\Service\SettingsService;
 use Kiener\MolliePayments\Setting\MollieSettingStruct;
 use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Profile;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
@@ -136,6 +137,19 @@ class SystemConfigSubscriber implements EventSubscriberInterface
         $this->apiClient->setApiKey($value);
 
         $profile = ProfileHelper::getProfile($this->apiClient, new MollieSettingStruct());
+
+        if(!$profile instanceof Profile) {
+            $this->logger->error(
+                'Could not get profile using these settings',
+                [
+                    'apiKey' => $value,
+                    'salesChannelId' => $salesChannelId ?? 'null',
+                    'mode' => $testMode ? 'test' : 'live',
+                ]
+            );
+            return;
+        }
+
         $this->profileIdStorage[$salesChannelId . $profileKey] = $profile->id;
 
         $this->logger->debug(


### PR DESCRIPTION
This occurs when
- iDeal is activated
- Mollie Limits are disabled
- An invalid API key is being used.

In this case iDeal will remain visible but we can't get available issuers from Mollie due to the invalid API key, and thus no issuers dropdown is available to register events on. If that's the case, skip rest of the plugin execution as everything hinges on the dropdown.