### PR TITLE
MOL-780: Mollie Limits must not be used in the Account area

### DIFF
--- a/src/Compatibility/Storefront/Route/PaymentMethodRoute/MollieLimits/MollieLimitsPaymentMethodRoute64.php
+++ b/src/Compatibility/Storefront/Route/PaymentMethodRoute/MollieLimits/MollieLimitsPaymentMethodRoute64.php
@@ -3,19 +3,11 @@
 namespace Kiener\MolliePayments\Compatibility\Storefront\Route\PaymentMethodRoute\MollieLimits;
 
 use Kiener\MolliePayments\Compatibility\Storefront\Route\PaymentMethodRoute\MollieLimits\Service\MollieLimitsRemover;
-use Kiener\MolliePayments\Service\Cart\Voucher\VoucherCartCollector;
-use Kiener\MolliePayments\Service\Cart\Voucher\VoucherService;
 use Kiener\MolliePayments\Service\Payment\Provider\ActivePaymentMethodsProviderInterface;
 use Kiener\MolliePayments\Service\SettingsService;
-use Kiener\MolliePayments\Setting\MollieSettingStruct;
-use Kiener\MolliePayments\Struct\PaymentMethod\PaymentMethodAttributes;
-use Mollie\Api\Resources\Method;
-use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
-use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Payment\SalesChannel\AbstractPaymentMethodRoute;
 use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRouteResponse;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
@@ -71,8 +63,12 @@ class MollieLimitsPaymentMethodRoute64 extends AbstractPaymentMethodRoute
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria): PaymentMethodRouteResponse
     {
         $originalData = $this->corePaymentMethodRoute->load($request, $context, $criteria);
-
-        return $this->mollieLimits->removePaymentMethods($originalData, $context);
+        $newData = $this->mollieLimits->removePaymentMethods($originalData, $context);
+        
+        if (count($newData->getPaymentMethods()) == 0) {
+            return $this->corePaymentMethodRoute->load($request, $context, $criteria);
+        }
+        return $newData;
     }
 
 }


### PR DESCRIPTION
The easiest way to fix this was loading the data again if removing resulted in empty data.