### PR TITLE
MOL-611 Cannot create a new payment when a Mollie order is cancelled or expired.

### DIFF
--- a/src/Exception/MollieOrderCancelledException.php
+++ b/src/Exception/MollieOrderCancelledException.php
@@ -6,6 +6,11 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class MollieOrderCancelledException extends ShopwareHttpException
 {
+    /**
+     * @param string               $mollieOrderID
+     * @param array<string, mixed> $parameters
+     * @param \Throwable|null      $e
+     */
     public function __construct(string $mollieOrderID, array $parameters = [], ?\Throwable $e = null)
     {
         $message = 'Mollie order {mollieId} is cancelled';

--- a/src/Exception/MollieOrderCancelledException.php
+++ b/src/Exception/MollieOrderCancelledException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kiener\MolliePayments\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+
+class MollieOrderCancelledException extends ShopwareHttpException
+{
+    public function __construct(string $mollieOrderID, array $parameters = [], ?\Throwable $e = null)
+    {
+        $message = 'Mollie order {mollieId} is cancelled';
+        $parameters['mollieId'] = $mollieOrderID;
+        parent::__construct($message, $parameters, $e);
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'MOLLIE_PAYMENTS__ORDER_IS_CANCELLED';
+    }
+}

--- a/src/Exception/MollieOrderExpiredException.php
+++ b/src/Exception/MollieOrderExpiredException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kiener\MolliePayments\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+
+class MollieOrderExpiredException extends ShopwareHttpException
+{
+    public function __construct(string $mollieOrderID, array $parameters = [], ?\Throwable $e = null)
+    {
+        $message = 'Mollie order {mollieId} is expired';
+        $parameters['mollieId'] = $mollieOrderID;
+        parent::__construct($message, $parameters, $e);
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'MOLLIE_PAYMENTS__ORDER_IS_EXPIRED';
+    }
+}

--- a/src/Exception/MollieOrderExpiredException.php
+++ b/src/Exception/MollieOrderExpiredException.php
@@ -6,6 +6,11 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class MollieOrderExpiredException extends ShopwareHttpException
 {
+    /**
+     * @param string               $mollieOrderID
+     * @param array<string, mixed> $parameters
+     * @param \Throwable|null      $e
+     */
     public function __construct(string $mollieOrderID, array $parameters = [], ?\Throwable $e = null)
     {
         $message = 'Mollie order {mollieId} is expired';

--- a/src/Facade/MolliePaymentDoPay.php
+++ b/src/Facade/MolliePaymentDoPay.php
@@ -4,6 +4,8 @@ namespace Kiener\MolliePayments\Facade;
 
 use Kiener\MolliePayments\Exception\CouldNotCreateMollieCustomerException;
 use Kiener\MolliePayments\Exception\CustomerCouldNotBeFoundException;
+use Kiener\MolliePayments\Exception\MollieOrderCancelledException;
+use Kiener\MolliePayments\Exception\MollieOrderExpiredException;
 use Kiener\MolliePayments\Exception\PaymentUrlException;
 use Kiener\MolliePayments\Handler\PaymentHandler;
 use Kiener\MolliePayments\Service\CustomerService;
@@ -137,16 +139,24 @@ class MolliePaymentDoPay
         # this is the case, if we already have a Mollie Order ID in our custom fields.
         # in this case, we just add a new payment (transaction) to the existing order in Mollie.
         if (!empty($mollieOrderId)) {
-            return $this->handleNextPaymentAttempt(
-                $order,
-                $swOrderTransactionID,
-                $orderCustomFields,
-                $mollieOrderId,
-                $paymentMethod,
-                $transactionStruct,
-                $salesChannelContext,
-                $paymentHandler
-            );
+            try {
+                return $this->handleNextPaymentAttempt(
+                    $order,
+                    $swOrderTransactionID,
+                    $orderCustomFields,
+                    $mollieOrderId,
+                    $paymentMethod,
+                    $transactionStruct,
+                    $salesChannelContext,
+                    $paymentHandler
+                );
+            } catch(MollieOrderCancelledException | MollieOrderExpiredException $e) {
+                # Warn about cancelled/expired order, but otherwise do nothing and let it create a new order.
+                $this->logger->warning($e->getMessage(), [
+                    'orderNumber' => $order->getOrderNumber(),
+                    'mollieOrderId' => $mollieOrderId
+                ]);
+            }
         }
 
         $this->logger->debug(


### PR DESCRIPTION
Orders usually expire after 28 days. There is a setting in the plugin configuration to set the expiration time to 1 day, but then you'd still have to wait a day testing.
It would be better to create a way to trigger a cancellation through the API.

Steps for testing:

1. Place an order in Shopware
2. Fail the payment on the payment screen
3. Cancel the order through the API, or set expiration time to 1 day and wait a day
4. Try to do the payment for the order in Shopware.