### PR TITLE
Log escaped mutants so we can improve our tests

### DIFF
--- a/.infection.json
+++ b/.infection.json
@@ -1,7 +1,7 @@
 {
   "bootstrap": "./phpunit.autoload.php",
-  "minMsi": 18,
-  "minCoveredMsi": 20,
+  "minMsi": 15,
+  "minCoveredMsi": 60,
   "source": {
     "directories": [
       "src"
@@ -15,6 +15,10 @@
   },
   "mutators": {
     "@default": true
+  },
+  "logs": {
+    "text": ".reports/infection/infection.log",
+    "summary": ".reports/infection/summary.log"
   },
   "$schema": "vendor/infection/infection/resources/schema.json"
 }

--- a/makefile
+++ b/makefile
@@ -65,7 +65,7 @@ phpunit: ## Starts all PHPUnit Tests
 	@XDEBUG_MODE=coverage php vendor/bin/phpunit --configuration=phpunit.xml --coverage-html ../../../public/.reports/mollie/coverage
 
 infection: ## Starts all Infection/Mutation tests
-	@XDEBUG_MODE=coverage php vendor/bin/infection --configuration=./.infection.json
+	phpdbg -qrr vendor/bin/infection --configuration=./.infection.json --log-verbosity=all --debug
 
 insights: ## Starts the PHPInsights Analyser
 	@php vendor/bin/phpinsights analyse --no-interaction

--- a/makefile
+++ b/makefile
@@ -65,7 +65,7 @@ phpunit: ## Starts all PHPUnit Tests
 	@XDEBUG_MODE=coverage php vendor/bin/phpunit --configuration=phpunit.xml --coverage-html ../../../public/.reports/mollie/coverage
 
 infection: ## Starts all Infection/Mutation tests
-	phpdbg -qrr vendor/bin/infection --configuration=./.infection.json --log-verbosity=all --debug
+	@XDEBUG_MODE=coverage php vendor/bin/infection --configuration=./.infection.json --log-verbosity=all --debug
 
 insights: ## Starts the PHPInsights Analyser
 	@php vendor/bin/phpinsights analyse --no-interaction


### PR DESCRIPTION
Create logs of our infection testing to see where mutants escape. This might help us improve our testing.
For now lower the minimum MSI as 75% of our code is uncovered.