### PR TITLE
MOL-859: The 'streetAdditional' field should not contain only whitespace characters

### DIFF
--- a/src/Service/MollieApi/Builder/MollieOrderAddressBuilder.php
+++ b/src/Service/MollieApi/Builder/MollieOrderAddressBuilder.php
@@ -20,7 +20,7 @@ class MollieOrderAddressBuilder
             'familyName' => $address->getLastName(),
             'email' => $email,
             'streetAndNumber' => $address->getStreet(),
-            'streetAdditional' => $address->getAdditionalAddressLine1(),
+            'streetAdditional' => trim($address->getAdditionalAddressLine1()) ?? null,
             'postalCode' => $address->getZipCode(),
             'city' => $address->getCity(),
             'country' => $address->getCountry() !== null ? $address->getCountry()->getIso() : self::MOLLIE_DEFAULT_COUNTRY_ISO,


### PR DESCRIPTION
Trimmed the value so whitespace characters at the start and end are removed. If the string ends up with a length of 0, send null instead