### PR TITLE
MOL-874: Use correct mandate ID of payment for subscription

### DIFF
--- a/src/Components/Subscription/Services/Builder/MollieDataBuilder.php
+++ b/src/Components/Subscription/Services/Builder/MollieDataBuilder.php
@@ -25,9 +25,10 @@ class MollieDataBuilder
 
     /**
      * @param SubscriptionEntity $subscription
+     * @param string $mandateId
      * @return array<mixed>
      */
-    public function buildDefinition(SubscriptionEntity $subscription): array
+    public function buildRequestPayload(SubscriptionEntity $subscription, string $mandateId): array
     {
         $metadata = $subscription->getMetadata();
 
@@ -46,6 +47,7 @@ class MollieDataBuilder
             'startDate' => $startDate,
             'interval' => $interval,
             'times' => $times,
+            'mandateId' => $mandateId,
         ];
     }
 }

--- a/src/Service/Mollie/MolliePaymentDetails.php
+++ b/src/Service/Mollie/MolliePaymentDetails.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Kiener\MolliePayments\Service\Mollie;
+
+use Mollie\Api\Resources\Payment;
+
+class MolliePaymentDetails
+{
+
+    /**
+     * @param null|Payment $payment
+     * @return string
+     */
+    public function getMandateId(?Payment $payment): string
+    {
+        if (!$payment instanceof Payment) {
+            return '';
+        }
+
+        if (!isset($payment->mandateId)) {
+            return '';
+        }
+
+        return (string)$payment->mandateId;
+    }
+}

--- a/src/Service/Mollie/OrderStatusConverter.php
+++ b/src/Service/Mollie/OrderStatusConverter.php
@@ -90,10 +90,11 @@ class OrderStatusConverter
     }
 
     /**
+     * @TODO we should move this somewhere else, but i had to (re)use this for now - so it's now public
      * @param Order $order
      * @return null|Payment
      */
-    private function getLatestPayment(Order $order): ?Payment
+    public function getLatestPayment(Order $order): ?Payment
     {
         $latestPayment = null;
 

--- a/tests/PHPUnit/Components/Subscription/Services/Builder/MollieDataBuilderTest.php
+++ b/tests/PHPUnit/Components/Subscription/Services/Builder/MollieDataBuilderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace PHPUnit\Components\Subscription\Services\Builder;
+
+use Kiener\MolliePayments\Components\Subscription\DAL\Subscription\Struct\SubscriptionMetadata;
+use Kiener\MolliePayments\Components\Subscription\DAL\Subscription\SubscriptionEntity;
+use Kiener\MolliePayments\Components\Subscription\Services\Builder\MollieDataBuilder;
+use Kiener\MolliePayments\Service\WebhookBuilder\WebhookBuilder;
+use MolliePayments\Tests\Fakes\FakePluginSettings;
+use MolliePayments\Tests\Fakes\FakeRouter;
+use PHPUnit\Framework\TestCase;
+
+class MollieDataBuilderTest extends TestCase
+{
+
+    /**
+     * This test verifies that our builder creates a correct
+     * payload structure for the subscription that should be created in Mollie.
+     * We build a SubscriptionEntity and let our builder convert that to our payload.
+     */
+    public function testBuildSubscriptionPayload()
+    {
+        $fakeRouter = new FakeRouter('https://local.mollie.shop/mollie/webhook/subscription/abc/renew');
+        $webhookBuilder = new WebhookBuilder($fakeRouter, new FakePluginSettings(''));
+        $builder = new MollieDataBuilder($webhookBuilder);
+
+
+        $subscription = new SubscriptionEntity();
+        $subscription->setId('ID123');
+        $subscription->setCurrency('USD');
+        $subscription->setAmount(10.5);
+        $subscription->setDescription('Subscription Product A');
+        $subscription->setMetadata(
+            new SubscriptionMetadata(
+                '2022-01-01',
+                2,
+                'days',
+                '5',
+                ''
+            )
+        );
+
+        $payload = $builder->buildRequestPayload($subscription, 'mdt_123');
+
+        $expected = [
+            'amount' => [
+                'currency' => 'USD',
+                'value' => '10.50',
+            ],
+            'description' => 'Subscription Product A',
+            'metadata' => [],
+            'webhookUrl' => 'https://local.mollie.shop/mollie/webhook/subscription/abc/renew',
+            'startDate' => '2022-01-01',
+            'interval' => '2 days',
+            'times' => 5,
+            'mandateId' => 'mdt_123',
+        ];
+
+        $this->assertEquals($expected, $payload);
+    }
+
+}

--- a/tests/PHPUnit/Service/Mollie/MolliePaymentDetailsTest.php
+++ b/tests/PHPUnit/Service/Mollie/MolliePaymentDetailsTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace MolliePayments\Tests\Service\Mollie;
+
+use Kiener\MolliePayments\Service\Mollie\MolliePaymentDetails;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Payment;
+use PHPUnit\Framework\TestCase;
+
+class MolliePaymentDetailsTest extends TestCase
+{
+
+    /**
+     * This test verifies that an existing mandate id
+     * is correctly found and returned
+     */
+    public function testMandateIDFound(): void
+    {
+        $fakePayment = new Payment(new MollieApiClient());
+        $fakePayment->mandateId = 'mdt_123';
+
+        $details = new MolliePaymentDetails();
+        $mandateId = $details->getMandateId($fakePayment);
+
+        $this->assertEquals('mdt_123', $mandateId);
+    }
+
+    /**
+     * This test verifies that we get an empty string
+     * if no mandate ID is found. So we unset the property
+     * in our stdClass object before we start the test.
+     */
+    public function testMandateIDNotFound(): void
+    {
+        $fakePayment = new Payment(new MollieApiClient());
+        unset($fakePayment->mandateId);
+
+        $details = new MolliePaymentDetails();
+        $mandateId = $details->getMandateId($fakePayment);
+
+        $this->assertEquals('', $mandateId);
+    }
+
+    /**
+     * This test verifies that we get an empty string
+     * if no payment is existing and provided for the function.
+     * This needs to exist for the fail-safe approach in the webhooks
+     */
+    public function testMandateEmptyWithoutPayment(): void
+    {
+        $details = new MolliePaymentDetails();
+        $mandateId = $details->getMandateId(null);
+
+        $this->assertEquals('', $mandateId);
+    }
+
+}


### PR DESCRIPTION
had to extract the mandateID from the paid payment that has been done
and reuse it when creating the subscription!

i did also rename the function into "buildPayload" because it makes more sense
and also added unit tests