### PR TITLE
MOL-586: Deactivate Payment Methods when uninstall plugin

### DIFF
--- a/src/Components/Installer/PluginInstaller.php
+++ b/src/Components/Installer/PluginInstaller.php
@@ -61,4 +61,15 @@ class PluginInstaller
 
         $this->applePayDomainService->downloadDomainAssociationFile();
     }
+
+    /**
+     * @param Context $context
+     * @return void
+     */
+    public function deactivate(Context $context):void
+    {
+        // Deactivation because removal is not possible because they might be attached to an order
+        $this->paymentMethodService->deactivatePaymentMethods($context);
+
+    }
 }

--- a/src/MolliePayments.php
+++ b/src/MolliePayments.php
@@ -126,6 +126,8 @@ class MolliePayments extends Plugin
     public function deactivate(DeactivateContext $context): void
     {
         parent::deactivate($context);
+
+        $this->deactivatePlugin($context->getContext());
     }
 
 
@@ -148,5 +150,17 @@ class MolliePayments extends Plugin
     private function runDbMigrations(MigrationCollection $migrationCollection): void
     {
         $migrationCollection->migrateInPlace();
+    }
+
+    /**
+     * @param Context $context
+     * @return void
+     */
+    private function deactivatePlugin(Context $context):void
+    {
+        /** @var PluginInstaller $pluginInstaller */
+        $pluginInstaller = $this->container->get(PluginInstaller::class);
+
+        $pluginInstaller->deactivate($context);
     }
 }

--- a/src/Service/PaymentMethodService.php
+++ b/src/Service/PaymentMethodService.php
@@ -115,6 +115,18 @@ class PaymentMethodService
     }
 
     /**
+     * @param Context $context
+     */
+    public function deactivatePaymentMethods(Context $context): void
+    {
+        $installedPaymentMethodHandlers = $this->getInstalledPaymentMethodHandlers($this->getPaymentHandlers(), $context);
+
+        foreach ($installedPaymentMethodHandlers as $installedPaymentMethodHandler) {
+            $this->disablePaymentMethod($installedPaymentMethodHandler, $context);
+        }
+    }
+
+    /**
      * @param array $paymentMethods
      * @param Context $context
      */


### PR DESCRIPTION
I've set this on the deactivate since this method is also called on uninstall, and if you deactivate the plugin you would invalidate the payment methods anyway