### PR TITLE
Added payment method api route to valid cart routes

### DIFF
--- a/src/Components/MollieLimits/Service/MollieLimitsRemover.php
+++ b/src/Components/MollieLimits/Service/MollieLimitsRemover.php
@@ -62,16 +62,19 @@ class MollieLimitsRemover extends PaymentMethodRemover
             return $originalData;
         }
 
-        try {
-            $cart = $this->getCart($context);
-        } catch (MissingCartServiceException $e) {
-            $this->logger->error($e->getMessage(), [
-                'exception' => $e,
-            ]);
-            return $originalData;
-        }
+        if ($this->isCartRoute()) {
+            try {
+                $cart = $this->getCart($context);
+            }
+            catch (MissingCartServiceException $e) {
+                $this->logger->error($e->getMessage(), [
+                    'exception' => $e,
+                ]);
+                return $originalData;
+            }
 
-        $price = $cart->getPrice()->getTotalPrice();
+            $price = $cart->getPrice()->getTotalPrice();
+        }
 
         if ($this->isOrderRoute()) {
             try {

--- a/src/Components/MollieLimits/Service/MollieLimitsRemover.php
+++ b/src/Components/MollieLimits/Service/MollieLimitsRemover.php
@@ -65,8 +65,7 @@ class MollieLimitsRemover extends PaymentMethodRemover
         if ($this->isCartRoute()) {
             try {
                 $cart = $this->getCart($context);
-            }
-            catch (MissingCartServiceException $e) {
+            } catch (MissingCartServiceException $e) {
                 $this->logger->error($e->getMessage(), [
                     'exception' => $e,
                 ]);
@@ -89,6 +88,9 @@ class MollieLimitsRemover extends PaymentMethodRemover
             $price = $order->getAmountTotal();
         }
 
+        if (!isset($price)) {
+            return $originalData;
+        }
 
         $availableMolliePayments = $this->paymentMethodsProvider->getActivePaymentMethodsForAmount(
             $price,
@@ -97,7 +99,6 @@ class MollieLimitsRemover extends PaymentMethodRemover
                 $context->getSalesChannel()->getId(),
             ]
         );
-
 
         /** @var PaymentMethodEntity $paymentMethod */
         foreach ($originalData->getPaymentMethods() as $paymentMethod) {

--- a/src/Service/Payment/Remover/CartAwareRouteInterface.php
+++ b/src/Service/Payment/Remover/CartAwareRouteInterface.php
@@ -9,6 +9,7 @@ interface CartAwareRouteInterface
         'frontend.checkout.confirm.page',
         'frontend.checkout.finish.page',
         'frontend.cart.offcanvas',
+        'store-api.payment.method',
     ];
 
     public function isCartRoute(string $route = ""): bool;


### PR DESCRIPTION
Please also try this, should work for all payment method removers then. with only exception if we somehow dont have a cart object available.