### PR TITLE
MOL-904: Reuse existing orders in subscription webhooks

### DIFF
--- a/src/Components/Subscription/SubscriptionManager.php
+++ b/src/Components/Subscription/SubscriptionManager.php
@@ -170,6 +170,21 @@ class SubscriptionManager implements SubscriptionManagerInterface
     }
 
     /**
+     * @param string $id
+     * @param Context $context
+     * @throws Exception
+     * @return SubscriptionEntity
+     */
+    public function findSubscription(string $id, Context $context): SubscriptionEntity
+    {
+        try {
+            return $this->repoSubscriptions->findById($id, $context);
+        } catch (\Throwable $ex) {
+            throw new Exception('Subscription with ID ' . $id . ' not found in Shopware');
+        }
+    }
+
+    /**
      * @param OrderEntity $order
      * @param SalesChannelContext $context
      * @throws Exception

--- a/src/Repository/Order/OrderRepository.php
+++ b/src/Repository/Order/OrderRepository.php
@@ -4,6 +4,9 @@ namespace Kiener\MolliePayments\Repository\Order;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 
 class OrderRepository
 {
@@ -20,6 +23,26 @@ class OrderRepository
     public function __construct(EntityRepositoryInterface $repoOrders)
     {
         $this->repoOrders = $repoOrders;
+    }
+
+
+    /**
+     * Searches orders of the provided customer with the provided Mollie ID (ord_xyz or tr_xyz) in Shopware.
+     * @param string $customerId
+     * @param string $mollieId
+     * @param Context $context
+     * @return \Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult
+     */
+    public function findByMollieId(string $customerId, string $mollieId, Context $context)
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('order.orderCustomer.customerId', $customerId));
+        $criteria->addFilter(new OrFilter([
+            new EqualsFilter('customFields.mollie_payments.order_id', $mollieId),
+            new EqualsFilter('customFields.mollie_payments.payment_id', $mollieId)
+        ]));
+
+        return $this->repoOrders->search($criteria, $context);
     }
 
     /**

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -135,6 +135,7 @@
         <service id="Kiener\MolliePayments\Controller\Storefront\Webhook\WebhookController" public="true">
             <argument type="service" id="Kiener\MolliePayments\Controller\Storefront\Webhook\NotificationFacade"/>
             <argument type="service" id="Kiener\MolliePayments\Components\Subscription\SubscriptionManager"/>
+            <argument type="service" id="Kiener\MolliePayments\Repository\Order\OrderRepository"/>
             <argument type="service" id="mollie_payments.logger"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -75,6 +75,7 @@
         <service id="Kiener\MolliePayments\Controller\Api\Webhook\WebhookController" public="true">
             <argument type="service" id="Kiener\MolliePayments\Controller\Storefront\Webhook\NotificationFacade"/>
             <argument type="service" id="Kiener\MolliePayments\Components\Subscription\SubscriptionManager"/>
+            <argument type="service" id="Kiener\MolliePayments\Repository\Order\OrderRepository"/>
             <argument type="service" id="mollie_payments.logger"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>


### PR DESCRIPTION
mollie also sends normal webhooks for subscriptions to this endpoint
so we need to check for existing orders and reuse this one