### PR TITLE
MOL-871: Webhook mails always have UTC time

### DIFF
--- a/src/Facade/MolliePaymentDoPay.php
+++ b/src/Facade/MolliePaymentDoPay.php
@@ -128,8 +128,8 @@ class MolliePaymentDoPay
      * @param AsyncPaymentTransactionStruct $transactionStruct
      * @param SalesChannelContext           $salesChannelContext
      * @param PaymentHandler                $paymentHandler
-     * @return MolliePaymentPrepareData
      * @throws ApiException
+     * @return MolliePaymentPrepareData
      */
     public function startMolliePayment(string $paymentMethod, AsyncPaymentTransactionStruct $transactionStruct, SalesChannelContext $salesChannelContext, PaymentHandler $paymentHandler): MolliePaymentPrepareData
     {
@@ -178,8 +178,7 @@ class MolliePaymentDoPay
                     $salesChannelContext,
                     $paymentHandler
                 );
-            }
-            catch (MollieOrderCancelledException|MollieOrderExpiredException $e) {
+            } catch (MollieOrderCancelledException|MollieOrderExpiredException $e) {
                 # Warn about cancelled/expired order, but otherwise do nothing and let it create a new order.
                 $this->logger->warning($e->getMessage(), [
                     'orderNumber'   => $order->getOrderNumber(),
@@ -261,8 +260,7 @@ class MolliePaymentDoPay
                     $salesChannelContext->getContext()
                 );
             }
-        }
-        catch (CouldNotCreateMollieCustomerException|CustomerCouldNotBeFoundException $e) {
+        } catch (CouldNotCreateMollieCustomerException|CustomerCouldNotBeFoundException $e) {
 
             # TODO do we really need to catch this? shouldnt it fail fast?
 
@@ -285,8 +283,8 @@ class MolliePaymentDoPay
      * @param AsyncPaymentTransactionStruct $transactionStruct
      * @param SalesChannelContext           $salesChannelContext
      * @param PaymentHandler                $paymentHandler
-     * @return MolliePaymentPrepareData
      * @throws ApiException|MollieOrderCancelledException|MollieOrderExpiredException
+     * @return MolliePaymentPrepareData
      */
     private function handleNextPaymentAttempt(OrderEntity $order, string $swOrderTransactionID, OrderAttributes $orderCustomFields, string $mollieOrderId, string $paymentMethod, AsyncPaymentTransactionStruct $transactionStruct, SalesChannelContext $salesChannelContext, PaymentHandler $paymentHandler): MolliePaymentPrepareData
     {
@@ -340,8 +338,8 @@ class MolliePaymentDoPay
      * @param AsyncPaymentTransactionStruct $transactionStruct
      * @param SalesChannelContext           $salesChannelContext
      * @param PaymentHandler                $paymentHandler
-     * @return MollieOrder
      * @throws \Exception
+     * @return MollieOrder
      */
     private function createMollieOrder(OrderEntity $orderEntity, string $paymentMethod, AsyncPaymentTransactionStruct $transactionStruct, SalesChannelContext $salesChannelContext, PaymentHandler $paymentHandler): \Mollie\Api\Resources\Order
     {

--- a/src/Resources/config/services/facades.xml
+++ b/src/Resources/config/services/facades.xml
@@ -26,6 +26,7 @@
             <argument type="service" id="Kiener\MolliePayments\Service\UpdateOrderCustomFields"/>
             <argument type="service" id="Kiener\MolliePayments\Service\Order\UpdateOrderLineItems"/>
             <argument type="service" id="Kiener\MolliePayments\Components\Subscription\SubscriptionManager"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="mollie_payments.logger"/>
         </service>
 
@@ -56,7 +57,7 @@
             <argument type="service" id="payment_method.repository"/>
             <argument type="service" id="order_transaction.repository"/>
         </service>
-        
+
         <service id="Kiener\MolliePayments\Facade\MollieSupportFacade">
             <argument type="service" id="mollie_payments.mail_service"/>
             <argument type="service" id="Kiener\MolliePayments\Service\Mail\AttachmentCollector"/>

--- a/src/Resources/config/services/subscriber.xml
+++ b/src/Resources/config/services/subscriber.xml
@@ -44,5 +44,10 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="Kiener\MolliePayments\Subscriber\WebhookTimezoneSubscriber">
+            <argument type="service" id="Kiener\MolliePayments\Service\TransactionService"/>
+            <argument type="service" id="mollie_payments.logger"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Struct/Order/OrderAttributes.php
+++ b/src/Struct/Order/OrderAttributes.php
@@ -79,6 +79,10 @@ class OrderAttributes
      */
     private $creditCardFeeRegion;
 
+    /**
+     * @var string
+     */
+    private $timezone;
 
     /**
      * @var OrderEntity
@@ -106,6 +110,7 @@ class OrderAttributes
         $this->creditCardCountryCode = $this->getCustomFieldValue($order, 'creditCardCountryCode');
         $this->creditCardSecurity = $this->getCustomFieldValue($order, 'creditCardSecurity');
         $this->creditCardFeeRegion = $this->getCustomFieldValue($order, 'creditCardFeeRegion');
+        $this->timezone = $this->getCustomFieldValue($order, 'timezone');
     }
 
     /**
@@ -311,6 +316,22 @@ class OrderAttributes
     }
 
     /**
+     * @return string
+     */
+    public function getTimezone(): string
+    {
+        return $this->timezone;
+    }
+
+    /**
+     * @param string $timezone
+     */
+    public function setTimezone(string $timezone): void
+    {
+        $this->timezone = $timezone;
+    }
+
+    /**
      * @param null|stdClass $details
      * @return void
      */
@@ -403,6 +424,10 @@ class OrderAttributes
 
         if ((string)$this->creditCardFeeRegion !== '') {
             $mollieData['creditCardFeeRegion'] = $this->creditCardFeeRegion;
+        }
+
+        if ((string)$this->timezone !== '') {
+            $mollieData['timezone'] = $this->timezone;
         }
 
         return [

--- a/src/Subscriber/WebhookTimezoneSubscriber.php
+++ b/src/Subscriber/WebhookTimezoneSubscriber.php
@@ -41,13 +41,12 @@ class WebhookTimezoneSubscriber implements EventSubscriberInterface
     public function __construct(
         TransactionService $transactionService,
         LoggerInterface    $logger
-    )
-    {
+    ) {
         $this->transactionService = $transactionService;
         $this->logger = $logger;
     }
 
-    public function fixWebhookTimezone(RequestEvent $event)
+    public function fixWebhookTimezone(RequestEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/src/Subscriber/WebhookTimezoneSubscriber.php
+++ b/src/Subscriber/WebhookTimezoneSubscriber.php
@@ -80,12 +80,14 @@ class WebhookTimezoneSubscriber implements EventSubscriberInterface
 
         if (!$transaction instanceof OrderTransactionEntity) {
             $this->logger->error(sprintf('Transaction for id %s does not exist', $transactionId));
+            return;
         }
 
         $order = $transaction->getOrder();
 
         if (!$order instanceof OrderEntity) {
             $this->logger->error(sprintf('Could not get order from transaction %s', $transactionId));
+            return;
         }
 
         $orderAttributes = new OrderAttributes($order);

--- a/tests/PHPUnit/Facade/MolliePaymentDoPayTest.php
+++ b/tests/PHPUnit/Facade/MolliePaymentDoPayTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Twig\Environment;
 
 class MolliePaymentDoPayTest extends TestCase
 {
@@ -92,6 +93,7 @@ class MolliePaymentDoPayTest extends TestCase
             $this->createMock(UpdateOrderCustomFields::class),
             $this->createMock(UpdateOrderLineItems::class),
             new FakeSubscriptionManager(),
+            $this->createMock(Environment::class),
             new NullLogger()
         );
     }

--- a/tests/PHPUnit/Subscriber/WebhookTimezoneSubscriberTest.php
+++ b/tests/PHPUnit/Subscriber/WebhookTimezoneSubscriberTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Storefront\Framework\Twig\TwigDateRequestListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -16,6 +17,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class WebhookTimezoneSubscriberTest extends TestCase
 {
+    private const WEBHOOK_ROUTE = 'frontend.mollie.webhook';
+    private const TRANSACTION_ID = 'abcdef0123456789abcdef0123456789';
     /**
      * @var WebhookTimezoneSubscriber
      */
@@ -39,6 +42,13 @@ class WebhookTimezoneSubscriberTest extends TestCase
     }
 
     /**
+     * Tests that the timezone is correctly set on the request when:
+     * 1: We're in the Mollie Webhook route
+     * 2: We have a swTransactionId, and it's valid
+     * 3: We can get an OrderTransactionEntity using the swTransactionId
+     * 4: The transaction entity contains an OrderEntity
+     * 5: And the order entity has a timezone set on its customFields.
+     *
      * @return void
      */
     public function testThatTimezoneIsCorrectlySet()
@@ -46,11 +56,122 @@ class WebhookTimezoneSubscriberTest extends TestCase
         $expectedTimezone = 'Europe/Amsterdam';
 
         $this->setUpTransactionService($this->createTransactionWithOrder($expectedTimezone));
-        $event = $this->setUpRequest('frontend.mollie.webhook', 'abcdef0123456789abcdef0123456789');
+        $event = $this->setUpRequest(self::WEBHOOK_ROUTE, self::TRANSACTION_ID);
+
+        $this->transactionService->expects($this->once())->method('getTransactionById');
 
         $this->subscriber->fixWebhookTimezone($event);
 
+        $this->assertArrayHasKey(TwigDateRequestListener::TIMEZONE_COOKIE, $this->request->cookies->all());
         $this->assertEquals($expectedTimezone, $this->request->cookies->get(TwigDateRequestListener::TIMEZONE_COOKIE));
+    }
+
+    /**
+     * Tests that the timezone cookie is not set by us when we're not on the mollie webhook route.
+     * @return void
+     */
+    public function testThatTimezoneIsNotSetWithIncorrectRoute()
+    {
+        $orderTimezone = 'Europe/Amsterdam';
+
+        $this->setUpTransactionService($this->createTransactionWithOrder($orderTimezone));
+        $event = $this->setUpRequest('some.random.route', self::TRANSACTION_ID);
+
+        $this->transactionService->expects($this->never())->method('getTransactionById');
+
+        $this->subscriber->fixWebhookTimezone($event);
+
+        $this->assertArrayNotHasKey(TwigDateRequestListener::TIMEZONE_COOKIE, $this->request->cookies->all());
+        $this->assertNull($this->request->cookies->get(TwigDateRequestListener::TIMEZONE_COOKIE));
+    }
+
+    /**
+     * Test that the timezone cookie is not set if we don't have a transaction id
+     * @return void
+     */
+    public function testThatTimezoneIsNotSetWithNoTransactionId()
+    {
+        $orderTimezone = 'Europe/Amsterdam';
+
+        $this->setUpTransactionService($this->createTransactionWithOrder($orderTimezone));
+        $event = $this->setUpRequest(self::WEBHOOK_ROUTE);
+
+        $this->transactionService->expects($this->never())->method('getTransactionById');
+
+        $this->subscriber->fixWebhookTimezone($event);
+
+        $this->assertArrayNotHasKey(TwigDateRequestListener::TIMEZONE_COOKIE, $this->request->cookies->all());
+        $this->assertNull($this->request->cookies->get(TwigDateRequestListener::TIMEZONE_COOKIE));
+    }
+
+    /**
+     * Tests that the timezone cookie is not set if we have an invalid transaction id
+     * @return void
+     */
+    public function testThatTimezoneIsNotSetWithIncorrectTransactionId()
+    {
+        $orderTimezone = 'Europe/Amsterdam';
+
+        $this->setUpTransactionService($this->createTransactionWithOrder($orderTimezone));
+        $event = $this->setUpRequest(self::WEBHOOK_ROUTE, 'foo');
+
+        $this->transactionService->expects($this->never())->method('getTransactionById');
+
+        $this->subscriber->fixWebhookTimezone($event);
+
+        $this->assertArrayNotHasKey(TwigDateRequestListener::TIMEZONE_COOKIE, $this->request->cookies->all());
+        $this->assertNull($this->request->cookies->get(TwigDateRequestListener::TIMEZONE_COOKIE));
+    }
+
+    /**
+     * Tests that the timezone cookie is not set if we don't have a transaction entity
+     * @return void
+     */
+    public function testThatTimezoneIsNotSetWithoutATransaction()
+    {
+        $this->setUpTransactionService(null);
+        $event = $this->setUpRequest(self::WEBHOOK_ROUTE, self::TRANSACTION_ID);
+
+        $this->transactionService->expects($this->once())->method('getTransactionById');
+
+        $this->subscriber->fixWebhookTimezone($event);
+
+        $this->assertArrayNotHasKey(TwigDateRequestListener::TIMEZONE_COOKIE, $this->request->cookies->all());
+        $this->assertNull($this->request->cookies->get(TwigDateRequestListener::TIMEZONE_COOKIE));
+    }
+
+    /**
+     * Tests that the timezone cookie is not set if we don't have an order entity
+     * @return void
+     */
+    public function testThatTimezoneIsNotSetWithoutAnOrder()
+    {
+        $this->setUpTransactionService($this->createMock(OrderTransactionEntity::class));
+        $event = $this->setUpRequest(self::WEBHOOK_ROUTE, self::TRANSACTION_ID);
+
+        $this->transactionService->expects($this->once())->method('getTransactionById');
+
+        $this->subscriber->fixWebhookTimezone($event);
+
+        $this->assertArrayNotHasKey(TwigDateRequestListener::TIMEZONE_COOKIE, $this->request->cookies->all());
+        $this->assertNull($this->request->cookies->get(TwigDateRequestListener::TIMEZONE_COOKIE));
+    }
+
+    /**
+     * Tests that the timezone cookie is not set if there's no timezone set on the order
+     * @return void
+     */
+    public function testThatTimezoneIsNotSetWithoutATimezoneCustomField()
+    {
+        $this->setUpTransactionService($this->createTransactionWithOrder());
+        $event = $this->setUpRequest(self::WEBHOOK_ROUTE, self::TRANSACTION_ID);
+
+        $this->transactionService->expects($this->once())->method('getTransactionById');
+
+        $this->subscriber->fixWebhookTimezone($event);
+
+        $this->assertArrayNotHasKey(TwigDateRequestListener::TIMEZONE_COOKIE, $this->request->cookies->all());
+        $this->assertNull($this->request->cookies->get(TwigDateRequestListener::TIMEZONE_COOKIE));
     }
 
     /**
@@ -78,10 +199,10 @@ class WebhookTimezoneSubscriberTest extends TestCase
 
     /**
      * Set up the transaction service with the provided transaction
-     * @param OrderTransactionEntity $transaction
+     * @param $transaction
      * @return void
      */
-    private function setUpTransactionService(OrderTransactionEntity $transaction): void
+    private function setUpTransactionService($transaction): void
     {
         $this->transactionService->method('getTransactionById')->willReturn($transaction);
     }

--- a/tests/PHPUnit/Subscriber/WebhookTimezoneSubscriberTest.php
+++ b/tests/PHPUnit/Subscriber/WebhookTimezoneSubscriberTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+namespace MolliePayments\Tests\Subscriber;
+
+use Kiener\MolliePayments\Service\TransactionService;
+use Kiener\MolliePayments\Subscriber\WebhookTimezoneSubscriber;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Storefront\Framework\Twig\TwigDateRequestListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class WebhookTimezoneSubscriberTest extends TestCase
+{
+    /**
+     * @var WebhookTimezoneSubscriber
+     */
+    protected $subscriber;
+
+    /**
+     * @var TransactionService&MockObject
+     */
+    protected $transactionService;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    public function setUp(): void
+    {
+        $this->transactionService = $this->createMock(TransactionService::class);
+
+        $this->subscriber = new WebhookTimezoneSubscriber($this->transactionService, new NullLogger());
+    }
+
+    /**
+     * @return void
+     */
+    public function testThatTimezoneIsCorrectlySet()
+    {
+        $expectedTimezone = 'Europe/Amsterdam';
+
+        $this->setUpTransactionService($this->createTransactionWithOrder($expectedTimezone));
+        $event = $this->setUpRequest('frontend.mollie.webhook', 'abcdef0123456789abcdef0123456789');
+
+        $this->subscriber->fixWebhookTimezone($event);
+
+        $this->assertEquals($expectedTimezone, $this->request->cookies->get(TwigDateRequestListener::TIMEZONE_COOKIE));
+    }
+
+    /**
+     * @param string $route
+     * @param string $transactionId
+     * @return RequestEvent
+     */
+    private function setUpRequest(string $route, string $transactionId = ''): RequestEvent
+    {
+        $this->request = new Request();
+        $this->request->attributes->set('_route', $route);
+
+        if(!empty($transactionId)) {
+            $this->request->attributes->set('_route_params', [
+                'swTransactionId' => $transactionId
+            ]);
+        }
+
+        return new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $this->request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+    }
+
+    /**
+     * Set up the transaction service with the provided transaction
+     * @param OrderTransactionEntity $transaction
+     * @return void
+     */
+    private function setUpTransactionService(OrderTransactionEntity $transaction): void
+    {
+        $this->transactionService->method('getTransactionById')->willReturn($transaction);
+    }
+
+    /**
+     * Returns a transaction entity containing an order entity with the specified timezone set.
+     * @param string $timezoneOnOrder
+     * @return OrderTransactionEntity
+     */
+    private function createTransactionWithOrder(string $timezoneOnOrder = ''): OrderTransactionEntity
+    {
+        $order = $this->createMock(OrderEntity::class);
+        if (!empty($timezoneOnOrder)) {
+            $order->method('getCustomFields')->willReturn([
+                'mollie_payments' => [
+                    'timezone' => $timezoneOnOrder
+                ]
+            ]);
+        }
+
+        return $this->createConfiguredMock(OrderTransactionEntity::class, [
+            'getOrder' => $order,
+        ]);
+    }
+}


### PR DESCRIPTION
Shopware reads the user's timezone from a cookie, and sets that in the twig environment. During webhook calls this cookie is unavailable, and will default to UTC.
To fix this we store the timezone in the order, and when webhooks are called we set this timezone on the twig environment.