### PR TITLE
Replace file_get_contents for HTTP requests with PSR HttpClient

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -53,6 +53,8 @@
             <argument type="service" id="Kiener\MolliePayments\Service\Transition\OrderTransitionService"/>
         </service>
 
+        <service id="kiener.mollie_payments.guzzle" class="GuzzleHttp\Client"/>
+
         <!-- Services -->
 
         <service id="Kiener\MolliePayments\Service\CustomerService" class="Kiener\MolliePayments\Service\CustomerService">
@@ -87,6 +89,8 @@
             <argument type="service" id="media.repository"/>
             <argument type="service" id="payment_method.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Plugin\Util\PluginIdProvider"/>
+            <argument type="service" id="kiener.mollie_payments.guzzle"/>
+            <argument type="service" id="Nyholm\Psr7\Factory\Psr17Factory"/>
         </service>
 
         <service id="Kiener\MolliePayments\Service\ProductService" class="Kiener\MolliePayments\Service\ProductService">

--- a/src/Resources/config/services/components.xml
+++ b/src/Resources/config/services/components.xml
@@ -53,6 +53,8 @@
 
         <service id="Kiener\MolliePayments\Components\ApplePayDirect\Services\ApplePayDomainVerificationService">
             <argument type="service" id="shopware.filesystem.public"/>
+            <argument type="service" id="kiener.mollie_payments.guzzle"/>
+            <argument type="service" id="Nyholm\Psr7\Factory\Psr17Factory"/>
         </service>
 
     </services>

--- a/src/Service/PaymentMethodService.php
+++ b/src/Service/PaymentMethodService.php
@@ -25,6 +25,8 @@ use Kiener\MolliePayments\Handler\Method\SofortPayment;
 use Kiener\MolliePayments\Handler\Method\VoucherPayment;
 use Kiener\MolliePayments\MolliePayments;
 use Mollie\Api\Resources\Order;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Content\Media\MediaCollection;
@@ -52,6 +54,12 @@ class PaymentMethodService
     /** @var EntityRepositoryInterface */
     private $mediaRepository;
 
+    /** @var ClientInterface */
+    private $httpClient;
+
+    /** @var RequestFactoryInterface */
+    private $httpRequestFactory;
+
     /**
      * PaymentMethodService constructor.
      *
@@ -59,17 +67,23 @@ class PaymentMethodService
      * @param EntityRepositoryInterface $mediaRepository
      * @param EntityRepositoryInterface $paymentRepository
      * @param PluginIdProvider $pluginIdProvider
+     * @param ClientInterface $httpClient
+     * @param RequestFactoryInterface $httpRequestFactory
      */
     public function __construct(
         MediaService              $mediaService,
         EntityRepositoryInterface $mediaRepository,
         EntityRepositoryInterface $paymentRepository,
-        PluginIdProvider          $pluginIdProvider
+        PluginIdProvider          $pluginIdProvider,
+        ClientInterface           $httpClient,
+        RequestFactoryInterface   $httpRequestFactory
     ) {
         $this->mediaService = $mediaService;
         $this->mediaRepository = $mediaRepository;
         $this->paymentRepository = $paymentRepository;
         $this->pluginIdProvider = $pluginIdProvider;
+        $this->httpClient = $httpClient;
+        $this->httpRequestFactory = $httpRequestFactory;
     }
 
     /**
@@ -416,10 +430,10 @@ class PaymentMethodService
         // Add icon to the media library
         $iconMime = 'image/svg+xml';
         $iconExt = 'svg';
-        $iconBlob = (string)file_get_contents('https://www.mollie.com/external/icons/payment-methods/' . $paymentMethod['name'] . '.svg');
+        $iconBlob = $this->downloadFile('https://www.mollie.com/external/icons/payment-methods/' . $paymentMethod['name'] . '.svg');
 
-        if (empty(trim($iconBlob))) {
-            $iconBlob = (string)file_get_contents('https://www.mollie.com/external/icons/payment-methods/' . $paymentMethod['name'] . '.png');
+        if ($iconBlob === null) {
+            $iconBlob = $this->downloadFile('https://www.mollie.com/external/icons/payment-methods/' . $paymentMethod['name'] . '.png');
             $iconMime = 'image/png';
             $iconExt = 'png';
         }
@@ -452,5 +466,28 @@ class PaymentMethodService
         }
 
         return $paymentMethod->getHandlerIdentifier() === ApplePayPayment::class && $mollieOrder->isPaid() === true;
+    }
+
+    private function downloadFile(string $url): ?string
+    {
+        try {
+            $response = $this->httpClient->sendRequest($this->httpRequestFactory->createRequest('GET', $url));
+
+            // the client should support follow redirect out of the box
+            if ($response->getStatusCode() >= 300) {
+                return null;
+            }
+
+            // should never happen as PSR describes that 1XX should be managed by the HttpClient
+            if ($response->getStatusCode() < 200) {
+                return null;
+            }
+
+            $body = (string) $response->getBody();
+
+            return $body !== '' ? $body : null;
+        } catch (\Throwable $_) {
+            return null;
+        }
     }
 }

--- a/src/Service/PaymentMethodService.php
+++ b/src/Service/PaymentMethodService.php
@@ -412,7 +412,7 @@ class PaymentMethodService
      *
      * @return string
      */
-    private function getMediaId(array $paymentMethod, Context $context): string
+    private function getMediaId(array $paymentMethod, Context $context): ?string
     {
         /** @var string $fileName */
         $fileName = $paymentMethod['name'] . '-icon';
@@ -436,6 +436,10 @@ class PaymentMethodService
             $iconBlob = $this->downloadFile('https://www.mollie.com/external/icons/payment-methods/' . $paymentMethod['name'] . '.png');
             $iconMime = 'image/png';
             $iconExt = 'png';
+        }
+
+        if ($iconBlob === null) {
+            return null;
         }
 
         return $this->mediaService->saveFile(

--- a/tests/PHPUnit/Service/PaymentMethodServiceTest.php
+++ b/tests/PHPUnit/Service/PaymentMethodServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Kiener\MolliePayments\Tests\Service;
 
+use GuzzleHttp\Client;
 use Kiener\MolliePayments\Handler\Method\ApplePayPayment;
 use Kiener\MolliePayments\Handler\Method\BanContactPayment;
 use Kiener\MolliePayments\Handler\Method\BankTransferPayment;
@@ -24,6 +25,7 @@ use Kiener\MolliePayments\Handler\Method\SofortPayment;
 use Kiener\MolliePayments\Handler\Method\VoucherPayment;
 use Kiener\MolliePayments\Service\PaymentMethodService;
 use MolliePayments\Tests\Fakes\FakeEntityRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\CashPayment;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\DebitPayment;
@@ -73,7 +75,9 @@ class PaymentMethodServiceTest extends TestCase
             $this->createMock(MediaService::class),
             $this->mediaRepository,
             $this->paymentMethodRepository,
-            $this->createMock(PluginIdProvider::class)
+            $this->createMock(PluginIdProvider::class),
+            new Client(),
+            new Psr17Factory()
         );
     }
 


### PR DESCRIPTION
When php directive `allow_url_fopen = Off` is set you cannot properly install the plugin. These parts fail:

* The Apple Merchant Id file is placed empty
* Every payment method media has content of 0 bytes
* Every payment method has a media file attached although they are "invalid"

Due to some restrictions it is very difficult to repair this as the uninstallation process is not very nice in Shopware with PSP plugins. You have to unflag the payment methods from this plugin to delete them properly, every media has to be deleted as well. This patch has to be applied OR allow_url_fopen needs to be active and plugin needs a reinstall.

With this PR they are still failing silent, but we try at least to pull HTTP data the HTTP way instead of looking on HTTP resources as if they were files.