### PR TITLE
fix: Change method of checking if constant exists

### DIFF
--- a/src/Struct/PaymentMethod/PaymentMethodAttributes.php
+++ b/src/Struct/PaymentMethod/PaymentMethodAttributes.php
@@ -50,10 +50,11 @@ class PaymentMethodAttributes
      */
     public function getMollieIdentifier(): string
     {
-        try {
-            return constant($this->handlerIdentifier . '::PAYMENT_METHOD_NAME') ?? '';
-        } catch (\Throwable $ex) {
+        if (!class_exists($this->handlerIdentifier)
+            || !defined("{$this->handlerIdentifier}::PAYMENT_METHOD_NAME")) {
             return '-';
         }
+
+        return constant($this->handlerIdentifier . '::PAYMENT_METHOD_NAME') ?? '';
     }
 }


### PR DESCRIPTION
and prevent a fatal error if the `handlerIdentifier` of the payment method is not a valid class.

We currently experience this in combination with the stripe plugin:
![fatal error](https://user-images.githubusercontent.com/6317761/198097486-f2efec3a-23fb-46c1-bf9a-38c0818a3558.png)

