### PR TITLE
NTR: Ensure that `title` never contains whitespace only

### DIFF
--- a/src/Service/MollieApi/Builder/MollieOrderAddressBuilder.php
+++ b/src/Service/MollieApi/Builder/MollieOrderAddressBuilder.php
@@ -20,7 +20,7 @@ class MollieOrderAddressBuilder
         }
 
         $data = [
-            'title' => ($address->getSalutation() !== null) ? $address->getSalutation()->getDisplayName() : null,
+            'title' => ($address->getSalutation() !== null) ? trim($address->getSalutation()->getDisplayName()) : null,
             'givenName' => $address->getFirstName(),
             'familyName' => $address->getLastName(),
             'email' => $email,

--- a/src/Service/MollieApi/Builder/MollieOrderAddressBuilder.php
+++ b/src/Service/MollieApi/Builder/MollieOrderAddressBuilder.php
@@ -20,7 +20,7 @@ class MollieOrderAddressBuilder
         }
 
         $data = [
-            'title' => ($address->getSalutation() !== null) ? trim($address->getSalutation()->getDisplayName()) : null,
+            'title' => ($address->getSalutation() !== null) ? trim((string)$address->getSalutation()->getDisplayName()) : null,
             'givenName' => $address->getFirstName(),
             'familyName' => $address->getLastName(),
             'email' => $email,

--- a/tests/PHPUnit/Service/MollieApi/Builder/MollieOrderAddressBuilderTest.php
+++ b/tests/PHPUnit/Service/MollieApi/Builder/MollieOrderAddressBuilderTest.php
@@ -79,6 +79,19 @@ class MollieOrderAddressBuilderTest extends TestCase
     }
 
     /**
+     * This test verifies that the value of a salutation (title in Mollies API)
+     * will never contain whitespace only.
+     */
+    public function testBuildWithWhitespaceSalutation(): void
+    {
+        $customerAddress = $this->buildFixture('  ', 'DE', '');
+
+        $addressData = $this->builder->build('test@mollie.com', $customerAddress);
+
+        self::assertEmpty($addressData['title']);
+    }
+
+    /**
      * This test verifies that the country should have NL as default value
      * if no ISO2 code has been provided (null)
      */


### PR DESCRIPTION
It might happen that the salutation/title wrongfully contains whitespace only. This will lead to Mollie rejecting the order with 

```
Error executing API call (422: Unprocessable Entity): The ‘title’ field should not contain only whitespace characters.
```

To prevent this, we `trim()` the display name of the salutation.