### PR TITLE
NTR: add flow builder order success event

### DIFF
--- a/src/Compatibility/Bundles/FlowBuilder/Events/Checkout/OrderSuccessEvent.php
+++ b/src/Compatibility/Bundles/FlowBuilder/Events/Checkout/OrderSuccessEvent.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Events\Checkout;
+
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Order\OrderDefinition;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\BusinessEventInterface;
+use Shopware\Core\Framework\Event\CustomerAware;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
+use Shopware\Core\Framework\Event\MailAware;
+use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Struct\JsonSerializableTrait;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class OrderSuccessEvent extends Event implements CustomerAware, MailAware, SalesChannelAware, BusinessEventInterface
+{
+    use JsonSerializableTrait;
+
+
+    /**
+     * @var OrderEntity
+     */
+    private $order;
+
+    /**
+     * @var CustomerEntity
+     */
+    private $customer;
+
+    /**
+     * @var Context
+     */
+    private $context;
+
+
+    /**
+     * @param OrderEntity $order
+     * @param CustomerEntity $customer
+     * @param Context $context
+     */
+    public function __construct(OrderEntity $order, CustomerEntity $customer, Context $context)
+    {
+        $this->order = $order;
+        $this->customer = $customer;
+        $this->context = $context;
+    }
+
+
+    /**
+     * @return EventDataCollection
+     */
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add('order', new EntityType(OrderDefinition::class))
+            ->add('customer', new EntityType(CustomerDefinition::class));
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'mollie.checkout.order_success';
+    }
+
+    /**
+     * @return Context
+     */
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    /**
+     * @return OrderEntity
+     */
+    public function getOrder(): OrderEntity
+    {
+        return $this->order;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCustomerId(): string
+    {
+        return $this->customer->getId();
+    }
+
+    /**
+     * @return CustomerEntity
+     */
+    public function getCustomer(): CustomerEntity
+    {
+        return $this->customer;
+    }
+
+    /**
+     * @return MailRecipientStruct
+     */
+    public function getMailStruct(): MailRecipientStruct
+    {
+        return new MailRecipientStruct([
+            $this->customer->getEmail() => sprintf('%s %s', $this->customer->getFirstName(), $this->customer->getLastName()),
+        ]);
+    }
+
+    /**
+     * @return string
+     */
+    public function getSalesChannelId(): string
+    {
+        return $this->customer->getSalesChannelId();
+    }
+}

--- a/src/Compatibility/Bundles/FlowBuilder/FlowBuilderEventFactory.php
+++ b/src/Compatibility/Bundles/FlowBuilder/FlowBuilderEventFactory.php
@@ -2,6 +2,7 @@
 
 namespace Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder;
 
+use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Events\Checkout\OrderSuccessEvent;
 use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Events\DummyEvent;
 use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Events\Refund\RefundStartedEvent;
 use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Events\Subscription\SubscriptionCancelledEvent;
@@ -336,5 +337,20 @@ class FlowBuilderEventFactory
         }
 
         return new SubscriptionRenewedEvent($subscription, $customer, $context);
+    }
+
+    /**
+     * @param CustomerEntity $customer
+     * @param OrderEntity $order
+     * @param Context $context
+     * @return DummyEvent|OrderSuccessEvent
+     */
+    public function buildOrderSuccessEvent(CustomerEntity $customer, OrderEntity $order, Context $context)
+    {
+        if ($this->versionCompare->lt(FlowBuilderFactory::FLOW_BUILDER_MIN_VERSION)) {
+            return new DummyEvent();
+        }
+
+        return new OrderSuccessEvent($order, $customer, $context);
     }
 }

--- a/src/Compatibility/Bundles/FlowBuilder/Subscriber/BusinessEventCollectorSubscriber.php
+++ b/src/Compatibility/Bundles/FlowBuilder/Subscriber/BusinessEventCollectorSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Subscriber;
 
+use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Events\Checkout\OrderSuccessEvent;
 use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Events\Refund\RefundStartedEvent;
 use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Events\Subscription\SubscriptionCancelledEvent;
 use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\Events\Subscription\SubscriptionEndedEvent;
@@ -64,6 +65,8 @@ class BusinessEventCollectorSubscriber implements EventSubscriberInterface
         $collection = $event->getCollection();
 
         $events = [
+            OrderSuccessEvent::class,
+            # --------------------------------------------
             WebhookReceivedEvent::class,
             # --------------------------------------------
             WebhookReceivedPaidEvent::class,

--- a/src/Handler/PaymentHandler.php
+++ b/src/Handler/PaymentHandler.php
@@ -2,6 +2,8 @@
 
 namespace Kiener\MolliePayments\Handler;
 
+use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\FlowBuilderEventFactory;
+use Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\FlowBuilderFactory;
 use Kiener\MolliePayments\Exception\PaymentUrlException;
 use Kiener\MolliePayments\Facade\MolliePaymentDoPay;
 use Kiener\MolliePayments\Facade\MolliePaymentFinalize;

--- a/src/Resources/app/administration/src/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/snippet/de-DE.json
@@ -1,6 +1,7 @@
 {
   "global": {
     "businessEvents": {
+      "mollie_checkout_order_success": " Bestellung erfolgreich",
       "mollie_webhook_received_All": " Mollie Webhook empfangen (Alle)",
       "mollie_webhook_received_status_authorized": " Mollie Webhook empfangen (Authorisiert)",
       "mollie_webhook_received_status_failed": " Mollie Webhook empfangen (Fehler)",
@@ -448,7 +449,8 @@
       "all": "Alle",
       "canceled": "Abgebrochen",
       "expired": "Abgelaufen",
-      "partiallyRefunded": "Rückerstattet (teilweise)"
+      "partiallyRefunded": "Rückerstattet (teilweise)",
+      "orderSuccess" : "Bestellung erfolgreich"
     }
   }
 }

--- a/src/Resources/app/administration/src/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/snippet/en-GB.json
@@ -1,6 +1,7 @@
 {
   "global": {
     "businessEvents": {
+      "mollie_checkout_order_success": " Order successful",
       "mollie_webhook_received_All": " Mollie Webhook Received (All)",
       "mollie_webhook_received_status_authorized": " Mollie Webhook Received (Authorized)",
       "mollie_webhook_received_status_failed": " Mollie Webhook Received (Failed)",
@@ -448,7 +449,8 @@
       "all": "All",
       "canceled": "Canceled",
       "expired": "Expired",
-      "partiallyRefunded": "Refunded (partially)"
+      "partiallyRefunded": "Refunded (partially)",
+      "orderSuccess" : "Order successful"
     }
   }
 }

--- a/src/Resources/app/administration/src/snippet/nl-NL.json
+++ b/src/Resources/app/administration/src/snippet/nl-NL.json
@@ -1,6 +1,7 @@
 {
   "global": {
     "businessEvents": {
+      "mollie_checkout_order_success": " Bestelling succesvol",
       "mollie_webhook_received_All": " Mollie Webhook Ontvangen (Alle)",
       "mollie_webhook_received_status_authorized": " Mollie Webhook Ontvangen (Geautoriseerd)",
       "mollie_webhook_received_status_failed": " Mollie Webhook Ontvangen (Mislukt)",
@@ -448,7 +449,8 @@
       "all": "Alle",
       "canceled": "Geannuleerd",
       "expired": "Verlopen",
-      "partiallyRefunded": "Terugbetaald (gedeeltelijk)"
+      "partiallyRefunded": "Terugbetaald (gedeeltelijk)",
+      "orderSuccess" : "Bestelling succesvol"
     }
   }
 }

--- a/src/Resources/config/services/facades.xml
+++ b/src/Resources/config/services/facades.xml
@@ -37,6 +37,9 @@
             <argument type="service" id="Kiener\MolliePayments\Service\MollieApi\Order"/>
             <argument type="service" id="Kiener\MolliePayments\Service\OrderService"/>
             <argument type="service" id="Kiener\MolliePayments\Components\Subscription\SubscriptionManager"/>
+            <argument type="service" id="customer.repository"/>
+            <argument type="service" id="Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\FlowBuilderFactory"/>
+            <argument type="service" id="Kiener\MolliePayments\Compatibility\Bundles\FlowBuilder\FlowBuilderEventFactory"/>
         </service>
 
         <service id="Kiener\MolliePayments\Facade\Controller\PaymentReturnFacade">

--- a/src/Service/OrderService.php
+++ b/src/Service/OrderService.php
@@ -88,6 +88,8 @@ class OrderService implements OrderServiceInterface
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('currency');
         $criteria->addAssociation('addresses');
+        $criteria->addAssociation('addresses.country');     # required for FlowBuilder -> send confirm email option
+        $criteria->addAssociation('shippingMethod');        # required for FlowBuilder -> send confirm email option
         $criteria->addAssociation('shippingAddress');   # important for subscription creation
         $criteria->addAssociation('billingAddress');    # important for subscription creation
         $criteria->addAssociation('billingAddress.country');


### PR DESCRIPTION
option to create flow builder based on (storefront) checkout events

this helps to e.g. send order confirmation mails when the user comes back from Mollie

<img width="671" alt="Screenshot 2023-01-29 at 11 37 04" src="https://user-images.githubusercontent.com/5579326/215320720-1337837f-ddd8-4ec2-800b-25f9a71ce176.png">
