### PR TITLE
NTR: add debug log when no subscription was created

### DIFF
--- a/src/Components/Subscription/Actions/CreateAction.php
+++ b/src/Components/Subscription/Actions/CreateAction.php
@@ -46,6 +46,7 @@ class CreateAction extends BaseAction
 
         if (!$attributes->isSubscriptionProduct()) {
             # Mixed carts are not allowed for subscriptions
+             $this->getLogger()->debug("Order {$order->getOrderNumber()} did not create a subscription.");
             return '';
         }
 


### PR DESCRIPTION
@boxblinkracer Just wanted to add a debug message when no subscription was created.
Turns out we accidentally got rid of custom fields when persisting the cart, but mollie subscriptions depend on them. So it made sense for me to now have it in debug mode even if no subscription is created.