### PR TITLE
MOL-982 Show Refunds in Storefront Account Orders

### DIFF
--- a/src/Resources/config/services/subscriber.xml
+++ b/src/Resources/config/services/subscriber.xml
@@ -56,5 +56,10 @@
             <argument type="service" id="mollie_payments.logger"/>
             <tag name="kernel.event_subscriber"/>
         </service>
+
+        <service id="Kiener\MolliePayments\Subscriber\AccountOrderPageLoadedSubscriber">
+            <argument type="service" id="Kiener\MolliePayments\Components\RefundManager\RefundManager"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/snippet/de_DE/mollie-payments.de-DE.json
+++ b/src/Resources/snippet/de_DE/mollie-payments.de-DE.json
@@ -1,116 +1,120 @@
 {
-    "checkout": {
-        "mollie-payments-cart-error-method-invalid": "Die aktuell gewählte Zahlungsmethode ist nicht für Abonnementprodukte verfügbar.",
-        "mollie-payments-cart-error-mixedcart": "Ihr Warenkorb enthält mehrere Artikel in Kombination mit Abonnementartikeln. Bitte beachten Sie, dass Sie jeweils nur 1 Abonnementartikel kaufen können.",
-        "mollie-payments-cart-error-paymentmethod-availability": "Bei der Bestellung von Abonnementprodukten sind nicht alle Zahlungsmethoden verfügbar.",
-        "mollie-payments-cart-guest-account": "Gäste Konten können nicht für Bestellungen von Abonnements benutzt werden."
+  "checkout": {
+    "mollie-payments-cart-error-method-invalid": "Die aktuell gewählte Zahlungsmethode ist nicht für Abonnementprodukte verfügbar.",
+    "mollie-payments-cart-error-mixedcart": "Ihr Warenkorb enthält mehrere Artikel in Kombination mit Abonnementartikeln. Bitte beachten Sie, dass Sie jeweils nur 1 Abonnementartikel kaufen können.",
+    "mollie-payments-cart-error-paymentmethod-availability": "Bei der Bestellung von Abonnementprodukten sind nicht alle Zahlungsmethoden verfügbar.",
+    "mollie-payments-cart-guest-account": "Gäste Konten können nicht für Bestellungen von Abonnements benutzt werden."
+  },
+  "error": {
+    "mollie-payments-cart-error-method-invalid": "Die aktuell gewählte Zahlungsmethode ist nicht für Abonnementprodukte verfügbar.",
+    "mollie-payments-cart-error-mixedcart": "Ihr Warenkorb enthält mehrere Artikel in Kombination mit Abonnementartikeln. Bitte beachten Sie, dass Sie jeweils nur 1 Abonnementartikel kaufen können.",
+    "mollie-payments-cart-error-paymentmethod-availability": "Bei der Bestellung von Abonnementprodukten sind nicht alle Zahlungsmethoden verfügbar.",
+    "mollie-payments-cart-guest-account": "Gäste Konten können nicht für Bestellungen von Abonnements benutzt werden."
+  },
+  "molliePayments": {
+    "components": {
+      "creditCard": {
+        "cardExpiryDateLabel": "MM/JJ",
+        "cardHolderLabel": "Name des Karteninhabers",
+        "cardNumberLabel": "Kreditkartennummer",
+        "cardVerificationCodeLabel": "CVV",
+        "creditCardTagLine": "Zahlung gesichert und zur Verfügung gestellt von",
+        "headLine": "Kreditkarteninformationen",
+        "saveCardDetailLabel": "Kartendaten für zukünftige Zahlungen speichern"
+      },
+      "ideal": {
+        "selectBank": "Bank auswählen"
+      },
+      "mandate": {
+        "sectionTitle": "Gespeicherte Karten",
+        "cardTitleLabel": "%name% •••• %number%",
+        "deleteSuccessMessage": "Ihre Karte wurde erfolgreich gelöscht",
+        "deleteErrorMessage": "Beim Entfernen Ihrer Karte ist ein Problem aufgetreten",
+        "newCard": "Neue Karte",
+        "remove": "Entfernen",
+        "subscriptionBadge": "Abonnement"
+      },
+      "mandateRemoveModal": {
+        "cancelButton": "Stornieren",
+        "cardSubscription": "Diese Karte wird für ein Abonnement verwendet. Bitte beenden Sie zuerst das Abonnement bevor Sie diese Karte löschen.",
+        "deleteButton": "Löschen",
+        "deleteConfirmation": "Sind Sie sicher, dass Sie die Zahlart löschen möchten?",
+        "title": "Bestätigung zum Löschen"
+      }
     },
-    "error": {
-        "mollie-payments-cart-error-method-invalid": "Die aktuell gewählte Zahlungsmethode ist nicht für Abonnementprodukte verfügbar.",
-        "mollie-payments-cart-error-mixedcart": "Ihr Warenkorb enthält mehrere Artikel in Kombination mit Abonnementartikeln. Bitte beachten Sie, dass Sie jeweils nur 1 Abonnementartikel kaufen können.",
-        "mollie-payments-cart-error-paymentmethod-availability": "Bei der Bestellung von Abonnementprodukten sind nicht alle Zahlungsmethoden verfügbar.",
-        "mollie-payments-cart-guest-account": "Gäste Konten können nicht für Bestellungen von Abonnements benutzt werden."
+    "messages": {
+      "payment": {
+        "buttonPayThroughMollie": "Bezahlen Sie mit einer anderen Zahlungsart",
+        "buttonReturnToShop": "Kehre zum Webshop zurück",
+        "error": "Zahlung fehlgeschlagen",
+        "failed": "Die Zahlung ist fehlgeschlagen oder wurde storniert. Sie werden zu Mollie weitergeleitet, wo Sie Ihre Zahlung mit der Methode Ihrer Wahl abschließen können. "
+      },
+      "redirecting": "Leiten Sie weiter zu: "
     },
-    "molliePayments": {
-        "components": {
-            "creditCard": {
-                "cardExpiryDateLabel": "MM/JJ",
-                "cardHolderLabel": "Name des Karteninhabers",
-                "cardNumberLabel": "Kreditkartennummer",
-                "cardVerificationCodeLabel": "CVV",
-                "creditCardTagLine": "Zahlung gesichert und zur Verfügung gestellt von",
-                "headLine": "Kreditkarteninformationen",
-                "saveCardDetailLabel": "Kartendaten für zukünftige Zahlungen speichern"
-            },
-            "ideal": {
-                "selectBank": "Bank auswählen"
-            },
-            "mandate": {
-                "sectionTitle": "Gespeicherte Karten",
-                "cardTitleLabel": "%name% •••• %number%",
-                "deleteSuccessMessage": "Ihre Karte wurde erfolgreich gelöscht",
-                "deleteErrorMessage": "Beim Entfernen Ihrer Karte ist ein Problem aufgetreten",
-                "newCard": "Neue Karte",
-                "remove": "Entfernen",
-                "subscriptionBadge" : "Abonnement"
-            },
-            "mandateRemoveModal": {
-                "cancelButton": "Stornieren",
-                "cardSubscription": "Diese Karte wird für ein Abonnement verwendet. Bitte beenden Sie zuerst das Abonnement bevor Sie diese Karte löschen.",
-                "deleteButton": "Löschen",
-                "deleteConfirmation": "Sind Sie sicher, dass Sie die Zahlart löschen möchten?",
-                "title": "Bestätigung zum Löschen"
-            }
-        },
-        "messages": {
-            "payment": {
-                "buttonPayThroughMollie": "Bezahlen Sie mit einer anderen Zahlungsart",
-                "buttonReturnToShop": "Kehre zum Webshop zurück",
-                "error": "Zahlung fehlgeschlagen",
-                "failed": "Die Zahlung ist fehlgeschlagen oder wurde storniert. Sie werden zu Mollie weitergeleitet, wo Sie Ihre Zahlung mit der Methode Ihrer Wahl abschließen können. "
-            },
-            "redirecting": "Leiten Sie weiter zu: "
-        },
-        "payments": {
-            "applePayDirect": {
-                "captionSubtotal": "Zwischensumme",
-                "captionTaxes": "Steuern",
-                "paymentError": "Die Zahlung mit Apple Pay ist fehlgeschlagen."
-            }
-        },
-        "subscriptions": {
-            "account": {
-                "btnEditBillingAddress": "Rechnungsadresse bearbeiten",
-                "btnEditShippingAddress": "Lieferadresse bearbeiten",
-                "cancelSubscription": "Das Abonnement wurde gekündigt",
-                "errorCancelSubscription": "Das Abonnement konnte aufgrund eines Fehlers nicht gekündigt werden. Bitte wenden Sie sich an unseren Support.",
-                "errorPause": "Dein Abonnement konnte nicht pausiert werden",
-                "errorResume": "Dein Abonnement konnte nicht fortgesetzt werden",
-                "errorSkip": "Dein Abonnement konnte nicht ausgesetzt werden",
-                "errorUpdateAddress": "Die Adresse konnte nicht aktualisiert werden",
-                "errorUpdatePayment": "Die Zahlungsart konnte nicht aktualisiert werden",
-                "headlineBillingAddress": "Rechnungsadresse",
-                "headlineShippingAddress": "Lieferadresse",
-                "mollieSubscriptionAmount": "Betragen",
-                "mollieSubscriptionCancel": "Abonnement kündigen",
-                "mollieSubscriptionCancelUntil": "Kündbar bis",
-                "mollieSubscriptionContextMenuReorder": "Abo wiederholen",
-                "mollieSubscriptionId": "Id",
-                "mollieSubscriptionNextPayment": "Nächste Zahlung um",
-                "mollieSubscriptionPause": "Abonnement pausieren",
-                "mollieSubscriptionResume": "Abonnement fortsetzen",
-                "mollieSubscriptionSkip": "Abonnement aussetzen",
-                "mollieSubscriptionUpdatePayment": "Zahlungsmethode aktualisieren",
-                "mollieSubscriptionsHeadline": "Abonnement:",
-                "mollieSubscriptionsInfoEmpty": "Sie haben noch keine Abonnements.",
-                "mollieSubscriptionsLink": "Abonnements",
-                "mollieSubscriptionsTitle": "Abonnements",
-                "mollieSubscriptionsWelcome": "Ihre letzten Abonnements:",
-                "orderActionHide": "Ausblenden",
-                "orderActionView": "Anzeigen",
-                "shippingEqualToBilling": "gleich wie Rechnungsadresse",
-                "successPause": "Dein Abonnement wurde pausiert",
-                "successResume": "Dein Abonnement wird nun wieder fortgesetzt",
-                "successSkip": "Dein Abonnement wird ausgesetzt",
-                "successUpdateAddress": "Deine Adresse wurde erfolgreich aktualisiert",
-                "successUpdatePayment": "Die Zahlungsart konnte erfolgreich aktualisiert werden"
-            },
-            "options": {
-                "everyDay": "Jeden Tag",
-                "everyDays": "Alle %value% Tage",
-                "everyMonth": "Jeden Monat",
-                "everyMonths": "Alle %value% Monate",
-                "everyWeek": "Jede Woche",
-                "everyWeeks": "Alle %value% Wochen",
-                "repetitionCount": "%value% mal"
-            },
-            "product": {
-                "addToCartText": "Abonnieren",
-                "information": "Abonnementprodukt"
-            }
-        },
-        "testMode": {
-            "label": "Testmodus"
-        }
+    "payments": {
+      "applePayDirect": {
+        "captionSubtotal": "Zwischensumme",
+        "captionTaxes": "Steuern",
+        "paymentError": "Die Zahlung mit Apple Pay ist fehlgeschlagen."
+      }
+    },
+    "subscriptions": {
+      "account": {
+        "btnEditBillingAddress": "Rechnungsadresse bearbeiten",
+        "btnEditShippingAddress": "Lieferadresse bearbeiten",
+        "cancelSubscription": "Das Abonnement wurde gekündigt",
+        "errorCancelSubscription": "Das Abonnement konnte aufgrund eines Fehlers nicht gekündigt werden. Bitte wenden Sie sich an unseren Support.",
+        "errorPause": "Dein Abonnement konnte nicht pausiert werden",
+        "errorResume": "Dein Abonnement konnte nicht fortgesetzt werden",
+        "errorSkip": "Dein Abonnement konnte nicht ausgesetzt werden",
+        "errorUpdateAddress": "Die Adresse konnte nicht aktualisiert werden",
+        "errorUpdatePayment": "Die Zahlungsart konnte nicht aktualisiert werden",
+        "headlineBillingAddress": "Rechnungsadresse",
+        "headlineShippingAddress": "Lieferadresse",
+        "mollieSubscriptionAmount": "Betragen",
+        "mollieSubscriptionCancel": "Abonnement kündigen",
+        "mollieSubscriptionCancelUntil": "Kündbar bis",
+        "mollieSubscriptionContextMenuReorder": "Abo wiederholen",
+        "mollieSubscriptionId": "Id",
+        "mollieSubscriptionNextPayment": "Nächste Zahlung um",
+        "mollieSubscriptionPause": "Abonnement pausieren",
+        "mollieSubscriptionResume": "Abonnement fortsetzen",
+        "mollieSubscriptionSkip": "Abonnement aussetzen",
+        "mollieSubscriptionUpdatePayment": "Zahlungsmethode aktualisieren",
+        "mollieSubscriptionsHeadline": "Abonnement:",
+        "mollieSubscriptionsInfoEmpty": "Sie haben noch keine Abonnements.",
+        "mollieSubscriptionsLink": "Abonnements",
+        "mollieSubscriptionsTitle": "Abonnements",
+        "mollieSubscriptionsWelcome": "Ihre letzten Abonnements:",
+        "orderActionHide": "Ausblenden",
+        "orderActionView": "Anzeigen",
+        "shippingEqualToBilling": "gleich wie Rechnungsadresse",
+        "successPause": "Dein Abonnement wurde pausiert",
+        "successResume": "Dein Abonnement wird nun wieder fortgesetzt",
+        "successSkip": "Dein Abonnement wird ausgesetzt",
+        "successUpdateAddress": "Deine Adresse wurde erfolgreich aktualisiert",
+        "successUpdatePayment": "Die Zahlungsart konnte erfolgreich aktualisiert werden"
+      },
+      "options": {
+        "everyDay": "Jeden Tag",
+        "everyDays": "Alle %value% Tage",
+        "everyMonth": "Jeden Monat",
+        "everyMonths": "Alle %value% Monate",
+        "everyWeek": "Jede Woche",
+        "everyWeeks": "Alle %value% Wochen",
+        "repetitionCount": "%value% mal"
+      },
+      "product": {
+        "addToCartText": "Abonnieren",
+        "information": "Abonnementprodukt"
+      }
+    },
+    "order": {
+      "refundedLabel": "Rückerstattet:",
+      "refundPendingLabel": "Rückerstattung ausstehend:"
+    },
+    "testMode": {
+      "label": "Testmodus"
     }
+  }
 }

--- a/src/Resources/snippet/en_GB/mollie-payments.en-GB.json
+++ b/src/Resources/snippet/en_GB/mollie-payments.en-GB.json
@@ -1,116 +1,120 @@
 {
-    "checkout": {
-        "mollie-payments-cart-error-method-invalid": "The currently selected payment method is not available for subscription products.",
-        "mollie-payments-cart-error-mixedcart": "Your cart contains multiple items in combination with subscription items. Please note you can only purchase 1 subscription item at a time.",
-        "mollie-payments-cart-error-paymentmethod-availability": "Not all payments methods are available when ordering subscription products.",
-        "mollie-payments-cart-guest-account": "Guest Accounts cannot be used for subscription orders."
+  "checkout": {
+    "mollie-payments-cart-error-method-invalid": "The currently selected payment method is not available for subscription products.",
+    "mollie-payments-cart-error-mixedcart": "Your cart contains multiple items in combination with subscription items. Please note you can only purchase 1 subscription item at a time.",
+    "mollie-payments-cart-error-paymentmethod-availability": "Not all payments methods are available when ordering subscription products.",
+    "mollie-payments-cart-guest-account": "Guest Accounts cannot be used for subscription orders."
+  },
+  "error": {
+    "mollie-payments-cart-error-method-invalid": "The currently selected payment method is not available for subscription products.",
+    "mollie-payments-cart-error-mixedcart": "Your cart contains multiple items in combination with subscription items. Please note you can only purchase 1 subscription item at a time.",
+    "mollie-payments-cart-error-paymentmethod-availability": "Not all payments methods are available when ordering subscription products.",
+    "mollie-payments-cart-guest-account": "Guest Accounts cannot be used for subscription orders."
+  },
+  "molliePayments": {
+    "components": {
+      "creditCard": {
+        "cardExpiryDateLabel": "Expiry date",
+        "cardHolderLabel": "Name on card",
+        "cardNumberLabel": "Card number",
+        "cardVerificationCodeLabel": "CVC/CVV",
+        "creditCardTagLine": "Payment secured and powered by",
+        "headLine": "Enter your card information",
+        "saveCardDetailLabel": "Save card details for future payments"
+      },
+      "ideal": {
+        "selectBank": "Select bank"
+      },
+      "mandate": {
+        "sectionTitle": "Saved cards",
+        "cardTitleLabel": "%name% •••• %number%",
+        "deleteSuccessMessage": "Your card was successfully deleted",
+        "deleteErrorMessage": "There was a problem when removing your card",
+        "newCard": "New card",
+        "remove": "Remove",
+        "subscriptionBadge": "Subscription"
+      },
+      "mandateRemoveModal": {
+        "cancelButton": "Cancel",
+        "cardSubscription": "This card is being used for a subscription. Please cancel the subscription first before removing this card.",
+        "deleteButton": "Delete",
+        "deleteConfirmation": "Are you sure you want to delete?",
+        "title": "Delete Confirmation"
+      }
     },
-    "error": {
-        "mollie-payments-cart-error-method-invalid": "The currently selected payment method is not available for subscription products.",
-        "mollie-payments-cart-error-mixedcart": "Your cart contains multiple items in combination with subscription items. Please note you can only purchase 1 subscription item at a time.",
-        "mollie-payments-cart-error-paymentmethod-availability": "Not all payments methods are available when ordering subscription products.",
-        "mollie-payments-cart-guest-account": "Guest Accounts cannot be used for subscription orders."
+    "messages": {
+      "payment": {
+        "buttonPayThroughMollie": "Pay with a different payment method",
+        "buttonReturnToShop": "Return to the shop",
+        "error": "Payment failed",
+        "failed": "The payment is failed or was canceled. You will be redirected to Mollie, where you can finish your payment with the method of your choice. "
+      },
+      "redirecting": "Redirecting you to: "
     },
-    "molliePayments": {
-        "components": {
-            "creditCard": {
-                "cardExpiryDateLabel": "Expiry date",
-                "cardHolderLabel": "Name on card",
-                "cardNumberLabel": "Card number",
-                "cardVerificationCodeLabel": "CVC/CVV",
-                "creditCardTagLine": "Payment secured and powered by",
-                "headLine": "Enter your card information",
-                "saveCardDetailLabel": "Save card details for future payments"
-            },
-            "ideal": {
-                "selectBank": "Select bank"
-            },
-            "mandate": {
-                "sectionTitle": "Saved cards",
-                "cardTitleLabel": "%name% •••• %number%",
-                "deleteSuccessMessage": "Your card was successfully deleted",
-                "deleteErrorMessage": "There was a problem when removing your card",
-                "newCard": "New card",
-                "remove": "Remove",
-                "subscriptionBadge" : "Subscription"
-            },
-            "mandateRemoveModal": {
-                "cancelButton": "Cancel",
-                "cardSubscription": "This card is being used for a subscription. Please cancel the subscription first before removing this card.",
-                "deleteButton": "Delete",
-                "deleteConfirmation": "Are you sure you want to delete?",
-                "title": "Delete Confirmation"
-            }
-        },
-        "messages": {
-            "payment": {
-                "buttonPayThroughMollie": "Pay with a different payment method",
-                "buttonReturnToShop": "Return to the shop",
-                "error": "Payment failed",
-                "failed": "The payment is failed or was canceled. You will be redirected to Mollie, where you can finish your payment with the method of your choice. "
-            },
-            "redirecting": "Redirecting you to: "
-        },
-        "payments": {
-            "applePayDirect": {
-                "captionSubtotal": "Subtotal",
-                "captionTaxes": "Taxes",
-                "paymentError": "The payment with Apple Pay failed."
-            }
-        },
-        "subscriptions": {
-            "account": {
-                "btnEditBillingAddress": "edit billing address",
-                "btnEditShippingAddress": "edit shipping address",
-                "cancelSubscription": "Subscription has been canceled",
-                "errorCancelSubscription": "The subscription could not be canceled due to an error. Please contact our support.",
-                "errorPause": "There was an error when pausing your subscription",
-                "errorResume": "There was an error when resuming your subscription",
-                "errorSkip": "There was an error when skipping your subscription",
-                "errorUpdateAddress": "There was an error when updating your address",
-                "errorUpdatePayment": "There was an error when updating your payment method",
-                "headlineBillingAddress": "Billing address",
-                "headlineShippingAddress": "Shipping address",
-                "mollieSubscriptionAmount": "Amount",
-                "mollieSubscriptionCancel": "Cancel Subscription",
-                "mollieSubscriptionCancelUntil": "Cancellation possible until",
-                "mollieSubscriptionContextMenuReorder": "Repeat subscription",
-                "mollieSubscriptionId": "Id",
-                "mollieSubscriptionNextPayment": "Next payment at",
-                "mollieSubscriptionPause": "Pause subscription",
-                "mollieSubscriptionResume": "Resume subscription",
-                "mollieSubscriptionSkip": "Skip subscription",
-                "mollieSubscriptionUpdatePayment": "Update payment",
-                "mollieSubscriptionsHeadline": "Subscription:",
-                "mollieSubscriptionsInfoEmpty": "You have no subscriptions yet.",
-                "mollieSubscriptionsLink": "Subscriptions",
-                "mollieSubscriptionsTitle": "Subscriptions",
-                "mollieSubscriptionsWelcome": "Your recent subscriptions:",
-                "orderActionHide": "Hide",
-                "orderActionView": "View",
-                "shippingEqualToBilling": "Equal to billing address",
-                "successPause": "Your subscription has been paused",
-                "successResume": "Your subscription will now be resumed",
-                "successSkip": "Your subscription has been skipped",
-                "successUpdateAddress": "Your address has been updated successfully",
-                "successUpdatePayment": "Your payment method has been updated successfully"
-            },
-            "options": {
-                "everyDay": "Every day",
-                "everyDays": "Every %value% days",
-                "everyMonth": "Every month",
-                "everyMonths": "Every %value% months",
-                "everyWeek": "Every week",
-                "everyWeeks": "Every %value% weeks",
-                "repetitionCount": "%value% time(s)"
-            },
-            "product": {
-                "addToCartText": "Subscribe",
-                "information": "Subscription product"
-            }
-        },
-        "testMode": {
-            "label": "Test mode"
-        }
+    "payments": {
+      "applePayDirect": {
+        "captionSubtotal": "Subtotal",
+        "captionTaxes": "Taxes",
+        "paymentError": "The payment with Apple Pay failed."
+      }
+    },
+    "subscriptions": {
+      "account": {
+        "btnEditBillingAddress": "edit billing address",
+        "btnEditShippingAddress": "edit shipping address",
+        "cancelSubscription": "Subscription has been canceled",
+        "errorCancelSubscription": "The subscription could not be canceled due to an error. Please contact our support.",
+        "errorPause": "There was an error when pausing your subscription",
+        "errorResume": "There was an error when resuming your subscription",
+        "errorSkip": "There was an error when skipping your subscription",
+        "errorUpdateAddress": "There was an error when updating your address",
+        "errorUpdatePayment": "There was an error when updating your payment method",
+        "headlineBillingAddress": "Billing address",
+        "headlineShippingAddress": "Shipping address",
+        "mollieSubscriptionAmount": "Amount",
+        "mollieSubscriptionCancel": "Cancel Subscription",
+        "mollieSubscriptionCancelUntil": "Cancellation possible until",
+        "mollieSubscriptionContextMenuReorder": "Repeat subscription",
+        "mollieSubscriptionId": "Id",
+        "mollieSubscriptionNextPayment": "Next payment at",
+        "mollieSubscriptionPause": "Pause subscription",
+        "mollieSubscriptionResume": "Resume subscription",
+        "mollieSubscriptionSkip": "Skip subscription",
+        "mollieSubscriptionUpdatePayment": "Update payment",
+        "mollieSubscriptionsHeadline": "Subscription:",
+        "mollieSubscriptionsInfoEmpty": "You have no subscriptions yet.",
+        "mollieSubscriptionsLink": "Subscriptions",
+        "mollieSubscriptionsTitle": "Subscriptions",
+        "mollieSubscriptionsWelcome": "Your recent subscriptions:",
+        "orderActionHide": "Hide",
+        "orderActionView": "View",
+        "shippingEqualToBilling": "Equal to billing address",
+        "successPause": "Your subscription has been paused",
+        "successResume": "Your subscription will now be resumed",
+        "successSkip": "Your subscription has been skipped",
+        "successUpdateAddress": "Your address has been updated successfully",
+        "successUpdatePayment": "Your payment method has been updated successfully"
+      },
+      "options": {
+        "everyDay": "Every day",
+        "everyDays": "Every %value% days",
+        "everyMonth": "Every month",
+        "everyMonths": "Every %value% months",
+        "everyWeek": "Every week",
+        "everyWeeks": "Every %value% weeks",
+        "repetitionCount": "%value% time(s)"
+      },
+      "product": {
+        "addToCartText": "Subscribe",
+        "information": "Subscription product"
+      }
+    },
+    "order": {
+      "refundedLabel": "Refunded:",
+      "refundPendingLabel": "Refund pending:"
+    },
+    "testMode": {
+      "label": "Test mode"
     }
+  }
 }

--- a/src/Resources/snippet/nl_NL/mollie-payments.nl-NL.json
+++ b/src/Resources/snippet/nl_NL/mollie-payments.nl-NL.json
@@ -1,116 +1,120 @@
 {
-    "checkout": {
-        "mollie-payments-cart-error-method-invalid": "De actueel geselecteerde betaalmethode is niet beschikbaar voor abonnementsproducten.",
-        "mollie-payments-cart-error-mixedcart": "Uw winkelwagen bevat meerdere artikelen in combinatie met abonnementsartikelen. Houd er rekening mee dat u slechts 1 abonnementsartikel tegelijk kunt kopen.",
-        "mollie-payments-cart-error-paymentmethod-availability": "Niet alle betaalmethoden zijn beschikbaar bij het bestellen van abonnementsproducten.",
-        "mollie-payments-cart-guest-account": "Gastaccounts kunnen niet worden gebruikt voor abonnementsbestellingen."
+  "checkout": {
+    "mollie-payments-cart-error-method-invalid": "De actueel geselecteerde betaalmethode is niet beschikbaar voor abonnementsproducten.",
+    "mollie-payments-cart-error-mixedcart": "Uw winkelwagen bevat meerdere artikelen in combinatie met abonnementsartikelen. Houd er rekening mee dat u slechts 1 abonnementsartikel tegelijk kunt kopen.",
+    "mollie-payments-cart-error-paymentmethod-availability": "Niet alle betaalmethoden zijn beschikbaar bij het bestellen van abonnementsproducten.",
+    "mollie-payments-cart-guest-account": "Gastaccounts kunnen niet worden gebruikt voor abonnementsbestellingen."
+  },
+  "error": {
+    "mollie-payments-cart-error-method-invalid": "De actueel geselecteerde betaalmethode is niet beschikbaar voor abonnementsproducten.",
+    "mollie-payments-cart-error-mixedcart": "Uw winkelwagen bevat meerdere artikelen in combinatie met abonnementsartikelen. Houd er rekening mee dat u slechts 1 abonnementsartikel tegelijk kunt kopen.",
+    "mollie-payments-cart-error-paymentmethod-availability": "Niet alle betaalmethoden zijn beschikbaar bij het bestellen van abonnementsproducten.",
+    "mollie-payments-cart-guest-account": "Gastaccounts kunnen niet worden gebruikt voor abonnementsbestellingen."
+  },
+  "molliePayments": {
+    "components": {
+      "creditCard": {
+        "cardExpiryDateLabel": "MM/JJ",
+        "cardHolderLabel": "Naam kaarthouder",
+        "cardNumberLabel": "Creditcardnummer",
+        "cardVerificationCodeLabel": "CVV",
+        "creditCardTagLine": "Betaling verzekerd en verzorgd door",
+        "headLine": "Credit card gegevens",
+        "saveCardDetailLabel": "Bewaar kaartgegevens voor toekomstige betalingen"
+      },
+      "ideal": {
+        "selectBank": "Selecteer bank"
+      },
+      "mandate": {
+        "sectionTitle": "Opgeslagen kaarten",
+        "cardTitleLabel": "%name% •••• %number%",
+        "deleteSuccessMessage": "Uw kaart is succesvol verwijderd",
+        "deleteErrorMessage": "Er is een probleem opgetreden bij het verwijderen van uw kaart",
+        "newCard": "Nieuwe kaart",
+        "remove": "Verwijderen",
+        "subscriptionBadge": "Abonnement"
+      },
+      "mandateRemoveModal": {
+        "cancelButton": "Annuleren",
+        "cardSubscription": "Deze kaart wordt gebruikt voor een abonnement. Annuleer eerst uw abonnement voordat u deze kaart verwijdert.",
+        "deleteButton": "Verwijderen",
+        "deleteConfirmation": "Weet je zeker dat je dat wilt verwijderen?",
+        "title": "Bevestiging verwijderen"
+      }
     },
-    "error": {
-        "mollie-payments-cart-error-method-invalid": "De actueel geselecteerde betaalmethode is niet beschikbaar voor abonnementsproducten.",
-        "mollie-payments-cart-error-mixedcart": "Uw winkelwagen bevat meerdere artikelen in combinatie met abonnementsartikelen. Houd er rekening mee dat u slechts 1 abonnementsartikel tegelijk kunt kopen.",
-        "mollie-payments-cart-error-paymentmethod-availability": "Niet alle betaalmethoden zijn beschikbaar bij het bestellen van abonnementsproducten.",
-        "mollie-payments-cart-guest-account": "Gastaccounts kunnen niet worden gebruikt voor abonnementsbestellingen."
+    "messages": {
+      "payment": {
+        "buttonPayThroughMollie": "Betaal met een andere betaalmethode",
+        "buttonReturnToShop": "Terug naar de webshop",
+        "error": "Betaling mislukt",
+        "failed": "De betaling is mislukt of geannuleerd. U wordt doorgestuurd naar Mollie waar u uw betaling kunt afronden met de methode naar keuze. "
+      },
+      "redirecting": "Doorsturen naar: "
     },
-    "molliePayments": {
-        "components": {
-            "creditCard": {
-                "cardExpiryDateLabel": "MM/JJ",
-                "cardHolderLabel": "Naam kaarthouder",
-                "cardNumberLabel": "Creditcardnummer",
-                "cardVerificationCodeLabel": "CVV",
-                "creditCardTagLine": "Betaling verzekerd en verzorgd door",
-                "headLine": "Credit card gegevens",
-                "saveCardDetailLabel": "Bewaar kaartgegevens voor toekomstige betalingen"
-            },
-            "ideal": {
-                "selectBank": "Selecteer bank"
-            },
-            "mandate": {
-                "sectionTitle": "Opgeslagen kaarten",
-                "cardTitleLabel": "%name% •••• %number%",
-                "deleteSuccessMessage": "Uw kaart is succesvol verwijderd",
-                "deleteErrorMessage": "Er is een probleem opgetreden bij het verwijderen van uw kaart",
-                "newCard": "Nieuwe kaart",
-                "remove": "Verwijderen",
-                "subscriptionBadge" : "Abonnement"
-            },
-            "mandateRemoveModal": {
-                "cancelButton": "Annuleren",
-                "cardSubscription": "Deze kaart wordt gebruikt voor een abonnement. Annuleer eerst uw abonnement voordat u deze kaart verwijdert.",
-                "deleteButton": "Verwijderen",
-                "deleteConfirmation": "Weet je zeker dat je dat wilt verwijderen?",
-                "title": "Bevestiging verwijderen"
-            }
-        },
-        "messages": {
-            "payment": {
-                "buttonPayThroughMollie": "Betaal met een andere betaalmethode",
-                "buttonReturnToShop": "Terug naar de webshop",
-                "error": "Betaling mislukt",
-                "failed": "De betaling is mislukt of geannuleerd. U wordt doorgestuurd naar Mollie waar u uw betaling kunt afronden met de methode naar keuze. "
-            },
-            "redirecting": "Doorsturen naar: "
-        },
-        "payments": {
-            "applePayDirect": {
-                "captionSubtotal": "Subtotaal",
-                "captionTaxes": "BTW",
-                "paymentError": "De betaling met Apple Pay is mislukt."
-            }
-        },
-        "subscriptions": {
-            "account": {
-                "btnEditBillingAddress": "factuuradres bewerken",
-                "btnEditShippingAddress": "verzendadres bewerken",
-                "cancelSubscription": "Abonnement is geannuleerd",
-                "errorCancelSubscription": "Door een fout kon het abonnement niet worden opgezegd. Neem dan contact op met onze ondersteuning.",
-                "errorPause": "There was an error when pausing your subscription",
-                "errorResume": "There was an error when resuming your subscription",
-                "errorSkip": "There was an error when skipping your subscription",
-                "errorUpdateAddress": "Er is een fout opgetreden bij het bijwerken van uw adres",
-                "errorUpdatePayment": "Er is een fout opgetreden bij het updaten van uw betaalmethode",
-                "headlineBillingAddress": "Facturatie adres",
-                "headlineShippingAddress": "Afleveradres",
-                "mollieSubscriptionAmount": "Hoeveelheid",
-                "mollieSubscriptionCancel": "Abonnement annuleren",
-                "mollieSubscriptionCancelUntil": "Annulering mogelijk tot",
-                "mollieSubscriptionContextMenuReorder": "Herhaal abonnement",
-                "mollieSubscriptionId": "Id",
-                "mollieSubscriptionNextPayment": "Volgende betaling bij",
-                "mollieSubscriptionPause": "Abonnement pauzeren",
-                "mollieSubscriptionResume": "Abonnement hervatten",
-                "mollieSubscriptionSkip": "Overslaan abonnement",
-                "mollieSubscriptionUpdatePayment": "Betaalmethode bijwerken",
-                "mollieSubscriptionsHeadline": "Abonnement:",
-                "mollieSubscriptionsInfoEmpty": "U heeft nog geen abonnementen.",
-                "mollieSubscriptionsLink": "Abonnementen",
-                "mollieSubscriptionsTitle": "Abonnementen",
-                "mollieSubscriptionsWelcome": "Uw recente abonnementen:",
-                "orderActionHide": "Verbergen",
-                "orderActionView": "Kijkje",
-                "shippingEqualToBilling": "Gelijk aan factuuradres",
-                "successPause": "Your subscription has been paused",
-                "successResume": "Your subscription will now be resumed",
-                "successSkip": "Your subscription has been skipped",
-                "successUpdateAddress": "Uw adres is succesvol bijgewerkt",
-                "successUpdatePayment": "De betaalmethode is succesvol geüpdatet"
-            },
-            "options": {
-                "everyDay": "Elke dag",
-                "everyDays": "Elke %value% dagen",
-                "everyMonth": "Elke maand",
-                "everyMonths": "Elke %value% maanden",
-                "everyWeek": "Elke week",
-                "everyWeeks": "Elke %value% weken",
-                "repetitionCount": "%value% keer"
-            },
-            "product": {
-                "addToCartText": "Abonneren",
-                "information": "Abonnement product"
-            }
-        },
-        "testMode": {
-            "label": "testmodus"
-        }
+    "payments": {
+      "applePayDirect": {
+        "captionSubtotal": "Subtotaal",
+        "captionTaxes": "BTW",
+        "paymentError": "De betaling met Apple Pay is mislukt."
+      }
+    },
+    "subscriptions": {
+      "account": {
+        "btnEditBillingAddress": "factuuradres bewerken",
+        "btnEditShippingAddress": "verzendadres bewerken",
+        "cancelSubscription": "Abonnement is geannuleerd",
+        "errorCancelSubscription": "Door een fout kon het abonnement niet worden opgezegd. Neem dan contact op met onze ondersteuning.",
+        "errorPause": "There was an error when pausing your subscription",
+        "errorResume": "There was an error when resuming your subscription",
+        "errorSkip": "There was an error when skipping your subscription",
+        "errorUpdateAddress": "Er is een fout opgetreden bij het bijwerken van uw adres",
+        "errorUpdatePayment": "Er is een fout opgetreden bij het updaten van uw betaalmethode",
+        "headlineBillingAddress": "Facturatie adres",
+        "headlineShippingAddress": "Afleveradres",
+        "mollieSubscriptionAmount": "Hoeveelheid",
+        "mollieSubscriptionCancel": "Abonnement annuleren",
+        "mollieSubscriptionCancelUntil": "Annulering mogelijk tot",
+        "mollieSubscriptionContextMenuReorder": "Herhaal abonnement",
+        "mollieSubscriptionId": "Id",
+        "mollieSubscriptionNextPayment": "Volgende betaling bij",
+        "mollieSubscriptionPause": "Abonnement pauzeren",
+        "mollieSubscriptionResume": "Abonnement hervatten",
+        "mollieSubscriptionSkip": "Overslaan abonnement",
+        "mollieSubscriptionUpdatePayment": "Betaalmethode bijwerken",
+        "mollieSubscriptionsHeadline": "Abonnement:",
+        "mollieSubscriptionsInfoEmpty": "U heeft nog geen abonnementen.",
+        "mollieSubscriptionsLink": "Abonnementen",
+        "mollieSubscriptionsTitle": "Abonnementen",
+        "mollieSubscriptionsWelcome": "Uw recente abonnementen:",
+        "orderActionHide": "Verbergen",
+        "orderActionView": "Kijkje",
+        "shippingEqualToBilling": "Gelijk aan factuuradres",
+        "successPause": "Your subscription has been paused",
+        "successResume": "Your subscription will now be resumed",
+        "successSkip": "Your subscription has been skipped",
+        "successUpdateAddress": "Uw adres is succesvol bijgewerkt",
+        "successUpdatePayment": "De betaalmethode is succesvol geüpdatet"
+      },
+      "options": {
+        "everyDay": "Elke dag",
+        "everyDays": "Elke %value% dagen",
+        "everyMonth": "Elke maand",
+        "everyMonths": "Elke %value% maanden",
+        "everyWeek": "Elke week",
+        "everyWeeks": "Elke %value% weken",
+        "repetitionCount": "%value% keer"
+      },
+      "product": {
+        "addToCartText": "Abonneren",
+        "information": "Abonnement product"
+      }
+    },
+    "order": {
+      "refundedLabel": "Terugbetaling:",
+      "refundPendingLabel": "Terugbetaling in afwachting:"
+    },
+    "testMode": {
+      "label": "testmodus"
     }
+  }
 }

--- a/src/Resources/views/storefront/page/account/order-history/order-detail.html.twig
+++ b/src/Resources/views/storefront/page/account/order-history/order-detail.html.twig
@@ -1,0 +1,39 @@
+{% sw_extends '@Storefront/storefront/page/account/order-history/order-detail.html.twig' %}
+{% block page_account_order_item_detail_amount_value %}
+    {{ parent() }}
+    {% set totals = order.extensions.mollie_refunds.totals %}
+
+    {% block page_account_order_item_detail_amount_mollie_refund_pending_label %}
+        {% if totals.pendingRefunds != 0 %}
+            <dt class="col-6 col-md-8">
+                {{ "molliePayments.order.refundPendingLabel"|trans|sw_sanitize }}
+            </dt>
+        {% endif %}
+    {% endblock %}
+
+    {% block page_account_order_item_detail_amount_mollie_refund_pending_value %}
+        {% if totals.pendingRefunds != 0 %}
+            <dd class="col-6 col-md-4">
+                {{ totals.pendingRefunds|currency(order.currency.isoCode) }}
+            </dd>
+        {% endif %}
+    {% endblock %}
+
+    {% block page_account_order_item_detail_amount_mollie_refunded_label %}
+        {% if totals.refunded != 0 %}
+            <dt class="col-6 col-md-8">
+                {{ "molliePayments.order.refundedLabel"|trans|sw_sanitize }}
+            </dt>
+        {% endif %}
+    {% endblock %}
+
+    {% block page_account_order_item_detail_amount_mollie_refunded_value %}
+        {% if totals.refunded != 0 %}
+            <dd class="col-6 col-md-4">
+                {{ totals.refunded|currency(order.currency.isoCode) }}
+            </dd>
+        {% endif %}
+    {% endblock %}
+
+
+{% endblock %}

--- a/src/Subscriber/AccountOrderPageLoadedSubscriber.php
+++ b/src/Subscriber/AccountOrderPageLoadedSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Kiener\MolliePayments\Subscriber;
+
+use Kiener\MolliePayments\Components\RefundManager\RefundManagerInterface;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Storefront\Page\Account\Order\AccountOrderPageLoadedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class AccountOrderPageLoadedSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var RefundManagerInterface
+     */
+    private $refundManager;
+
+    /**
+     *
+     */
+    public function __construct(RefundManagerInterface $refundManager)
+    {
+        $this->refundManager = $refundManager;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            AccountOrderPageLoadedEvent::class => 'onAccountOrderPageLoaded'
+        ];
+    }
+
+    /**
+     * @param AccountOrderPageLoadedEvent $event
+     * @return void
+     */
+    public function onAccountOrderPageLoaded(AccountOrderPageLoadedEvent $event)
+    {
+        # Add the refunds for the order history details page
+        $orders = $event->getPage()->getOrders();
+        /** @var OrderEntity $order */
+        foreach ($orders as $order) {
+           $data =  $this->refundManager->getData($order,$event->getContext());
+            $order->addArrayExtension("mollie_refunds",$data->toArray());
+        }
+
+    }
+}


### PR DESCRIPTION
This is done on page load now, but this loads Mollie orders for every order. Should it be converted to a Ajax call with widget route and throbber for quicker page load?