### PR TITLE
MOL-1166: Show warning for high order lifetime days

### DIFF
--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/index.js
@@ -25,8 +25,7 @@ Component.register('mollie-pluginconfig-section-order-lifetime-warning', {
     },
     methods: {
         createdComponent() {
-            const maximumOrderLifeTimeKlarna = 28;
-            const maximumOrderLifeTime = 100;
+
             /**
              * The input element is displayed later, so we have to wait until it is inside the dom document
              */
@@ -38,19 +37,21 @@ Component.register('mollie-pluginconfig-section-order-lifetime-warning', {
                 }
                 clearInterval(interval);
 
-                const orderLifeTime = parseInt(orderLifeTimeElement.value);
-                this.oderLifeTimeLimitReached = orderLifeTime > maximumOrderLifeTime;
-                this.klarnaOrderLifeTimeReached = !this.oderLifeTimeLimitReached && orderLifeTime > maximumOrderLifeTimeKlarna;
+                this.toggleWarning(orderLifeTimeElement);
 
                 orderLifeTimeElement.addEventListener("keyup", (event) => {
-                    const orderLifeTime = parseInt(event.target.value);
-                    this.oderLifeTimeLimitReached = orderLifeTime > maximumOrderLifeTime;
-                    this.klarnaOrderLifeTimeReached = !this.oderLifeTimeLimitReached && orderLifeTime > maximumOrderLifeTimeKlarna;
+                    this.toggleWarning(event.target);
                 }, true);
 
             }, 500);
-
         },
 
+        toggleWarning(element){
+            const maximumOrderLifeTimeKlarna = 28;
+            const maximumOrderLifeTime = 100;
+            const orderLifeTime = parseInt(element.value);
+            this.oderLifeTimeLimitReached = orderLifeTime > maximumOrderLifeTime;
+            this.klarnaOrderLifeTimeReached = !this.oderLifeTimeLimitReached && orderLifeTime > maximumOrderLifeTimeKlarna;
+        },
     },
 });

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/index.js
@@ -1,0 +1,56 @@
+import template from './mollie-pluginconfig-section-order-lifetime-warning.twig';
+
+
+// eslint-disable-next-line no-undef
+const {Component, Mixin} = Shopware;
+
+Component.register('mollie-pluginconfig-section-order-lifetime-warning', {
+    template,
+
+    inject: [
+        'MolliePaymentsConfigService',
+    ],
+
+    mixins: [
+        Mixin.getByName('notification'),
+    ],
+    data() {
+        return {
+            oderLifeTimeLimitReached: false,
+            klarnaOrderLifeTimeReached: false,
+        };
+    },
+    created() {
+        this.createdComponent();
+    },
+    methods: {
+        createdComponent() {
+            const maximumOrderLifeTimeKlarna = 28;
+            const maximumOrderLifeTime = 100;
+            /**
+             * The input element is displayed later, so we have to wait until it is inside the dom document
+             */
+            const interval = setInterval(() => {
+                const orderLifeTimeElement = document.querySelector('input[name="MolliePayments.config.orderLifetimeDays"]');
+
+                if (orderLifeTimeElement === null) {
+                    return;
+                }
+                clearInterval(interval);
+
+                const orderLifeTime = parseInt(orderLifeTimeElement.value);
+                this.oderLifeTimeLimitReached = orderLifeTime > maximumOrderLifeTime;
+                this.klarnaOrderLifeTimeReached = !this.oderLifeTimeLimitReached && orderLifeTime > maximumOrderLifeTimeKlarna;
+
+                orderLifeTimeElement.addEventListener("keyup", (event) => {
+                    const orderLifeTime = parseInt(event.target.value);
+                    this.oderLifeTimeLimitReached = orderLifeTime > maximumOrderLifeTime;
+                    this.klarnaOrderLifeTimeReached = !this.oderLifeTimeLimitReached && orderLifeTime > maximumOrderLifeTimeKlarna;
+                }, true);
+
+            }, 500);
+
+        },
+
+    },
+});

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/index.js
@@ -38,16 +38,16 @@ Component.register('mollie-pluginconfig-section-order-lifetime-warning', {
                 }
                 clearInterval(interval);
                 const value =  parseInt(orderLifeTimeElement.value);
-                limitDetector.checkValue(value);
-                this.oderLifeTimeLimitReached = limitDetector.isOderLifeTimeLimitReached();
-                this.klarnaOrderLifeTimeReached = limitDetector.isKlarnaOrderLifeTimeReached();
+
+                this.oderLifeTimeLimitReached = limitDetector.isOderLifeTimeLimitReached(value);
+                this.klarnaOrderLifeTimeReached = limitDetector.isKlarnaOrderLifeTimeReached(value);
 
 
                 orderLifeTimeElement.addEventListener("keyup", (event) => {
                     const value =  parseInt(event.target.value);
-                    limitDetector.checkValue(value);
-                    this.oderLifeTimeLimitReached = limitDetector.isOderLifeTimeLimitReached();
-                    this.klarnaOrderLifeTimeReached = limitDetector.isKlarnaOrderLifeTimeReached();
+
+                    this.oderLifeTimeLimitReached = limitDetector.isOderLifeTimeLimitReached(value);
+                    this.klarnaOrderLifeTimeReached = limitDetector.isKlarnaOrderLifeTimeReached(value);
                 }, true);
 
             }, 500);

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/index.js
@@ -1,4 +1,5 @@
 import template from './mollie-pluginconfig-section-order-lifetime-warning.twig';
+import OrderLifeTimeLimitsDetectorService from './services/OderLifeTimeLimitDetectorService';
 
 
 // eslint-disable-next-line no-undef
@@ -25,7 +26,7 @@ Component.register('mollie-pluginconfig-section-order-lifetime-warning', {
     },
     methods: {
         createdComponent() {
-
+            const limitDetector = new OrderLifeTimeLimitsDetectorService()
             /**
              * The input element is displayed later, so we have to wait until it is inside the dom document
              */
@@ -36,22 +37,20 @@ Component.register('mollie-pluginconfig-section-order-lifetime-warning', {
                     return;
                 }
                 clearInterval(interval);
+                const value =  parseInt(orderLifeTimeElement.value);
+                limitDetector.checkValue(value);
+                this.oderLifeTimeLimitReached = limitDetector.isOderLifeTimeLimitReached();
+                this.klarnaOrderLifeTimeReached = limitDetector.isKlarnaOrderLifeTimeReached();
 
-                this.toggleWarning(orderLifeTimeElement);
 
                 orderLifeTimeElement.addEventListener("keyup", (event) => {
-                    this.toggleWarning(event.target);
+                    const value =  parseInt(event.target.value);
+                    limitDetector.checkValue(value);
+                    this.oderLifeTimeLimitReached = limitDetector.isOderLifeTimeLimitReached();
+                    this.klarnaOrderLifeTimeReached = limitDetector.isKlarnaOrderLifeTimeReached();
                 }, true);
 
             }, 500);
-        },
-
-        toggleWarning(element){
-            const maximumOrderLifeTimeKlarna = 28;
-            const maximumOrderLifeTime = 100;
-            const orderLifeTime = parseInt(element.value);
-            this.oderLifeTimeLimitReached = orderLifeTime > maximumOrderLifeTime;
-            this.klarnaOrderLifeTimeReached = !this.oderLifeTimeLimitReached && orderLifeTime > maximumOrderLifeTimeKlarna;
         },
     },
 });

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/mollie-pluginconfig-section-order-lifetime-warning.twig
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/mollie-pluginconfig-section-order-lifetime-warning.twig
@@ -1,0 +1,8 @@
+<sw-container gap="16px">
+    <sw-alert v-if="klarnaOrderLifeTimeReached" class="bankTransferDueDateKlarnaLimitReached" variant="warning" :showIcon="true" :closable="false">
+        {{ $tc('mollie-payments.config.order.bankTransferDueDateKlarnaLimitReached') }}
+    </sw-alert>
+    <sw-alert v-if="oderLifeTimeLimitReached" class="bankTransferDueDateLimitReached" variant="error" :showIcon="true" :closable="false">
+        {{ $tc('mollie-payments.config.order.bankTransferDueDateLimitReached') }}
+    </sw-alert>
+</sw-container>

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/services/OderLifeTimeLimitDetectorService.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/services/OderLifeTimeLimitDetectorService.js
@@ -1,0 +1,20 @@
+export default class OrderLifeTimeLimitsDetector {
+    maximumOrderLifeTimeKlarna = 28;
+    maximumOrderLifeTime = 100;
+    oderLifeTimeLimitReached = false;
+    klarnaOrderLifeTimeReached = false;
+
+    checkValue(orderLifeTime) {
+        this.oderLifeTimeLimitReached = orderLifeTime > this.maximumOrderLifeTime;
+        this.klarnaOrderLifeTimeReached = !this.oderLifeTimeLimitReached && orderLifeTime > this.maximumOrderLifeTimeKlarna;
+    }
+
+    isOderLifeTimeLimitReached() {
+        return this.oderLifeTimeLimitReached;
+    }
+
+    isKlarnaOrderLifeTimeReached() {
+        return this.klarnaOrderLifeTimeReached;
+    }
+
+}

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/services/OderLifeTimeLimitDetectorService.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/services/OderLifeTimeLimitDetectorService.js
@@ -1,20 +1,13 @@
 export default class OrderLifeTimeLimitsDetector {
     maximumOrderLifeTimeKlarna = 28;
     maximumOrderLifeTime = 100;
-    oderLifeTimeLimitReached = false;
-    klarnaOrderLifeTimeReached = false;
 
-    checkValue(orderLifeTime) {
-        this.oderLifeTimeLimitReached = orderLifeTime > this.maximumOrderLifeTime;
-        this.klarnaOrderLifeTimeReached = !this.oderLifeTimeLimitReached && orderLifeTime > this.maximumOrderLifeTimeKlarna;
+    isOderLifeTimeLimitReached(orderLifeTime) {
+        return orderLifeTime > this.maximumOrderLifeTime;
     }
 
-    isOderLifeTimeLimitReached() {
-        return this.oderLifeTimeLimitReached;
-    }
-
-    isKlarnaOrderLifeTimeReached() {
-        return this.klarnaOrderLifeTimeReached;
+    isKlarnaOrderLifeTimeReached(orderLifeTime) {
+        return orderLifeTime > this.maximumOrderLifeTimeKlarna && orderLifeTime <= this.maximumOrderLifeTime;
     }
 
 }

--- a/src/Resources/app/administration/src/module/mollie-payments/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/index.js
@@ -8,6 +8,7 @@ import './components/mollie-pluginconfig-section-payments';
 import './components/mollie-pluginconfig-section-payments-format';
 import './components/mollie-pluginconfig-section-rounding';
 import './components/mollie-pluginconfig-support-modal';
+import './components/mollie-pluginconfig-section-order-lifetime-warning';
 import './components/mollie-tracking-info';
 import './components/mollie-refund-manager';
 import './components/mollie-external-link';

--- a/src/Resources/app/administration/src/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/snippet/de-DE.json
@@ -80,6 +80,10 @@
         "info2": "Diese Einstellungen können zu einer anderen Gesamtsumme als der Gesamtsumme der Einzelposten führen. Wenn Mollie diese Beträge abgleicht und feststellt, dass sie nicht übereinstimmen, verursacht dies einen Fehler.",
         "info3": "Sie können diese Funktion verwenden, um Rundungsprobleme in Ihrem Checkout zu vermeiden. Wenn diese aktiviert ist, fügt sie eine separate Position im Mollie-Dashboard für die Rundungsdifferenz hinzu, und die Kunden zahlen die von Shopware berechnete Gesamtsumme."
       },
+      "order": {
+        "bankTransferDueDateKlarnaLimitReached": "Es ist nicht möglich, Klarna Pay now, Klarna Slice it oder Klarna Pay later als Zahlungsmethode zu verwenden, wenn Ihr Ablaufdatum mehr als 28 Tage in der Zukunft liegt, es sei denn, zwischen dem Händler und Klarna wurde eine andere Höchstgrenze vereinbart.",
+        "bankTransferDueDateLimitReached": "Es ist nicht möglich, die Bestelllaufzeit auf mehr als 100 Tage festzulegen."
+      },
       "support": {
         "modalTitle": "Unterstützung von Mollie anfordern",
         "btnCancel": "Abbrechen",

--- a/src/Resources/app/administration/src/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/snippet/en-GB.json
@@ -80,6 +80,10 @@
         "info2": "These settings can lead to a different grand total than the total sum of line items. When Mollie cross-checks these amounts and finds that they don’t match, it causes a checkout error.",
         "info3": "You can use this feature to avoid rounding issues in your checkout. When enabled, it adds a separate line item in your Mollie Dashboard for the difference in rounding, and your customers pay the grand total calculated by Shopware."
       },
+      "order": {
+        "bankTransferDueDateKlarnaLimitReached": "It is not possible to use Klarna Pay now, Klarna Slice it or Klarna Pay later as method when your expiry date is more than 28 days in the future, unless another maximum is agreed between the merchant and Klarna.",
+        "bankTransferDueDateLimitReached": "It is not possible to set the order life time higher than 100 days."
+      },
       "support": {
         "modalTitle": "Request support from Mollie",
         "btnCancel": "Cancel",

--- a/src/Resources/app/administration/src/snippet/nl-NL.json
+++ b/src/Resources/app/administration/src/snippet/nl-NL.json
@@ -80,6 +80,10 @@
         "info2": "Deze instellingen kunnen leiden tot een andere totale som dan de totale som van lineitems. Wanneer Mollie deze bedragen kruiselings controleert en vaststelt dat ze niet overeenkomen, ontstaat er een fout bij het afrekenen.",
         "info3": "Je kunt deze functie gebruiken om afrondingsproblemen bij het afrekenen te voorkomen. Indien ingeschakeld, voegt het een apart lineitem toe aan je Mollie Dashboard met het afrondingsverschil, en betalen je klanten de totale som zoals berekend door Shopware."
       },
+      "order": {
+        "bankTransferDueDateKlarnaLimitReached": "Het is niet mogelijk om Klarna Pay now, Klarna Slice it of Klarna Pay later als methode te gebruiken wanneer de vervaldatum meer dan 28 dagen in de toekomst ligt, tenzij een ander maximum is overeengekomen tussen de merchant en Klarna.",
+        "bankTransferDueDateLimitReached": "Het is niet mogelijk om de orderlevensduur langer dan 100 dagen in te stellen."
+      },
       "support": {
         "modalTitle": "Verzoek support van Mollie",
         "btnCancel": "Cancel",

--- a/src/Resources/app/administration/tests/components/mollie-pluginconfig-section-order-lifetime-warning/service/OderLifeTimeLimitDetectorService.spec.js
+++ b/src/Resources/app/administration/tests/components/mollie-pluginconfig-section-order-lifetime-warning/service/OderLifeTimeLimitDetectorService.spec.js
@@ -1,0 +1,21 @@
+import OderLifeTimeLimitDetectorService from './../../../../../administration/src/module/mollie-payments/components/mollie-pluginconfig-section-order-lifetime-warning/services/OderLifeTimeLimitDetectorService';
+
+const service = new OderLifeTimeLimitDetectorService();
+
+test('No warnings are shown', () => {
+    service.checkValue(0);
+    expect(service.isKlarnaOrderLifeTimeReached()).toBe(false);
+    expect(service.isOderLifeTimeLimitReached()).toBe(false);
+});
+
+test('Klarna Limit reached', () => {
+    service.checkValue(29);
+    expect(service.isKlarnaOrderLifeTimeReached()).toBe(true);
+    expect(service.isOderLifeTimeLimitReached()).toBe(false);
+});
+
+test('Order Limit reached', () => {
+    service.checkValue(101);
+    expect(service.isKlarnaOrderLifeTimeReached()).toBe(false);
+    expect(service.isOderLifeTimeLimitReached()).toBe(true);
+});

--- a/src/Resources/app/administration/tests/components/mollie-pluginconfig-section-order-lifetime-warning/service/OderLifeTimeLimitDetectorService.spec.js
+++ b/src/Resources/app/administration/tests/components/mollie-pluginconfig-section-order-lifetime-warning/service/OderLifeTimeLimitDetectorService.spec.js
@@ -3,19 +3,19 @@ import OderLifeTimeLimitDetectorService from './../../../../../administration/sr
 const service = new OderLifeTimeLimitDetectorService();
 
 test('No warnings are shown', () => {
-    service.checkValue(0);
-    expect(service.isKlarnaOrderLifeTimeReached()).toBe(false);
-    expect(service.isOderLifeTimeLimitReached()).toBe(false);
+    const oderLifeTime = 0;
+    expect(service.isKlarnaOrderLifeTimeReached(oderLifeTime)).toBe(false);
+    expect(service.isOderLifeTimeLimitReached(oderLifeTime)).toBe(false);
 });
 
 test('Klarna Limit reached', () => {
-    service.checkValue(29);
-    expect(service.isKlarnaOrderLifeTimeReached()).toBe(true);
-    expect(service.isOderLifeTimeLimitReached()).toBe(false);
+    const oderLifeTime = 29;
+    expect(service.isKlarnaOrderLifeTimeReached(oderLifeTime)).toBe(true);
+    expect(service.isOderLifeTimeLimitReached(oderLifeTime)).toBe(false);
 });
 
 test('Order Limit reached', () => {
-    service.checkValue(101);
-    expect(service.isKlarnaOrderLifeTimeReached()).toBe(false);
-    expect(service.isOderLifeTimeLimitReached()).toBe(true);
+    const oderLifeTime = 101;
+    expect(service.isKlarnaOrderLifeTimeReached(oderLifeTime)).toBe(false);
+    expect(service.isOderLifeTimeLimitReached(oderLifeTime)).toBe(true);
 });

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -191,6 +191,9 @@
             <helpText lang="de-DE">Konfiguration eines eigenen Verfallsdatums für die Zahlungsart 'Bank Transfer'. Dies ist der Zeitraum einer möglichen Zahlung bis die Zahlungsmöglichkeit verfällt.</helpText>
             <helpText lang="nl-NL">Wijs een aangepaste "vervaldatum" toe voor de betaalmethode Bankoverschrijving. Dit is de periode dat de klant kan betalen totdat de betaling vervalt.</helpText>
         </input-field>
+        <component name="mollie-pluginconfig-section-order-lifetime-warning">
+            <name>molliePluginConfigSectionOrderLifeTimeWarning</name>
+        </component>
         <input-field type="int">
             <name>orderLifetimeDays</name>
             <label>Order Lifetime Days</label>

--- a/tests/Cypress/cypress/e2e/admin/plugin-config.cy.js
+++ b/tests/Cypress/cypress/e2e/admin/plugin-config.cy.js
@@ -103,5 +103,27 @@ context("Plugin Config", () => {
             cy.get(divPreview).should('be.visible');
             cy.contains(divPreview, '"cypress_1000-stage"');
         })
+
+        it('Display order lifetime days warning', () => {
+
+            adminLogin.login();
+            pluginAction.openPluginConfiguration();
+
+            const inputField = cy.get('#MolliePayments\\.config\\.orderLifetimeDays');
+            const errorDiv = '.bankTransferDueDateLimitReached';
+            const klarnaWarningDiv = '.bankTransferDueDateKlarnaLimitReached';
+
+            inputField.clear().type('10');
+            cy.get(klarnaWarningDiv).should('not.exist');
+            cy.get(errorDiv).should('not.exist');
+
+            inputField.clear().type('30');
+            cy.get(klarnaWarningDiv).should('exist');
+            cy.get(errorDiv).should('not.exist');
+
+            inputField.clear().type('101');
+            cy.get(klarnaWarningDiv).should('not.exist');
+            cy.get(errorDiv).should('exist');
+        })
     })
 })

--- a/tests/Cypress/cypress/e2e/admin/plugin-config.cy.js
+++ b/tests/Cypress/cypress/e2e/admin/plugin-config.cy.js
@@ -109,21 +109,38 @@ context("Plugin Config", () => {
             adminLogin.login();
             pluginAction.openPluginConfiguration();
 
-            const inputField = cy.get('#MolliePayments\\.config\\.orderLifetimeDays');
+
+            const inputField = '#MolliePayments\\.config\\.orderLifetimeDays';
             const errorDiv = '.bankTransferDueDateLimitReached';
             const klarnaWarningDiv = '.bankTransferDueDateKlarnaLimitReached';
 
-            inputField.clear().type('10');
-            cy.get(klarnaWarningDiv).should('not.exist');
-            cy.get(errorDiv).should('not.exist');
 
-            inputField.clear().type('30');
+            cy.get(inputField).clear().type('101');
+            cy.get(klarnaWarningDiv).should('not.exist');
+            cy.get(errorDiv).should('exist');
+
+            pluginAction.savePlugConfiguration();
+            cy.get(klarnaWarningDiv).should('not.exist');
+            cy.get(errorDiv).should('exist');
+
+            cy.get(inputField).clear().type('30');
             cy.get(klarnaWarningDiv).should('exist');
             cy.get(errorDiv).should('not.exist');
 
-            inputField.clear().type('101');
+            pluginAction.savePlugConfiguration();
+            cy.get(klarnaWarningDiv).should('exist');
+            cy.get(errorDiv).should('not.exist');
+
+
+            cy.get(inputField).clear().type('0');
             cy.get(klarnaWarningDiv).should('not.exist');
-            cy.get(errorDiv).should('exist');
+            cy.get(errorDiv).should('not.exist');
+
+            pluginAction.savePlugConfiguration();
+            cy.get(klarnaWarningDiv).should('not.exist');
+            cy.get(errorDiv).should('not.exist');
+
+
         })
     })
 })

--- a/tests/Cypress/cypress/e2e/admin/plugin-config.cy.js
+++ b/tests/Cypress/cypress/e2e/admin/plugin-config.cy.js
@@ -104,7 +104,7 @@ context("Plugin Config", () => {
             cy.contains(divPreview, '"cypress_1000-stage"');
         })
 
-        it('Display order lifetime days warning', () => {
+        it('C1097313: Display order lifetime days warning', () => {
 
             adminLogin.login();
             pluginAction.openPluginConfiguration();

--- a/tests/Cypress/cypress/support/actions/admin/AdminPluginAction.js
+++ b/tests/Cypress/cypress/support/actions/admin/AdminPluginAction.js
@@ -19,4 +19,9 @@ export default class AdminPluginAction {
         cy.wait(4000);
     }
 
+    savePlugConfiguration() {
+        cy.get('.sw-extension-config__save-action').click();
+        cy.wait(4000);
+    }
+
 }


### PR DESCRIPTION
This PR shows a warning if the order lifetime days is higher than 28, because Klarna has a limit of 28 days (could be higher depends on merchant)

And shows an error if there are more than 100 days