### PR TITLE
Include lineItems with quantity=0 in composition metadata

### DIFF
--- a/src/Service/Refund/Mollie/RefundMetadata.php
+++ b/src/Service/Refund/Mollie/RefundMetadata.php
@@ -85,10 +85,6 @@ class RefundMetadata
         ];
 
         foreach ($this->items as $item) {
-            if ($item->getQuantity() <= 0) {
-                continue;
-            }
-
             $swLineId = $this->dataCompression->compress($item->getShopwareLineID());
 
             $data['composition'][] = [


### PR DESCRIPTION
The quantity of a refund line item should not decide whether it will be included in the composition of the refund. Here is a scenario:

1. Let's say I have a line item in an order with a quantity of 1.
2. I issue a refund for said line item with quantity=1 and only half the amount.
3. The customer complains about my mistake and I come back to correct it.

Now I must issue a refund for the line item with the remaining amount, but I can only choose a quantity of 0. But that doesn't change the fact that this refund affects this line item and hence should list it in the composition.

FYI: My perspective on this is from an API consumer. So I consume the API provided by this plugin that will in turn consume the API of the Mollie platform.