### PR TITLE
Allow salesChannelId to be missing

### DIFF
--- a/src/Subscriber/SystemConfigSubscriber.php
+++ b/src/Subscriber/SystemConfigSubscriber.php
@@ -56,7 +56,7 @@ class SystemConfigSubscriber implements EventSubscriberInterface
             $this->checkSystemConfigChange(
                 (string)$payload['configurationKey'],
                 $payload['configurationValue'],
-                $payload['salesChannelId'],
+                $payload['salesChannelId'] ?? null,
                 $event->getContext()
             );
         }


### PR DESCRIPTION
nwdxxItRechtConnector seems to create an entry without the salesChannelId, which is okay to do, but I get

```
[ErrorException]
Warning: Undefined array key "salesChannelId"
```
