### PR TITLE
Expose refund amount to flow.

### DIFF
--- a/src/Compatibility/Bundles/FlowBuilder/Events/Refund/RefundStarted/RefundStartedEvent.php
+++ b/src/Compatibility/Bundles/FlowBuilder/Events/Refund/RefundStarted/RefundStartedEvent.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Event\BusinessEventInterface;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Event\SalesChannelAware;
@@ -59,6 +60,7 @@ class RefundStartedEvent extends Event implements OrderAware, MailAware, SalesCh
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
+            ->add('amount', new ScalarValueType(ScalarValueType::TYPE_FLOAT))
             ->add('order', new EntityType(OrderDefinition::class));
     }
 

--- a/src/Compatibility/Bundles/FlowBuilder/Events/Refund/RefundStarted/RefundStartedEvent651.php
+++ b/src/Compatibility/Bundles/FlowBuilder/Events/Refund/RefundStarted/RefundStartedEvent651.php
@@ -12,6 +12,7 @@ class RefundStartedEvent651 extends RefundStartedEvent implements ScalarValuesAw
     public function getValues(): array
     {
         return [
+            'amount' => $this->amount,
             'order' => $this->order,
         ];
     }


### PR DESCRIPTION
This allows the flow builder to access the refund amount, e.g. for customer mails.

Example in a mail template:
```
{{ amount | currency(order.currency.isoCode) }}
```