### PR TITLE
MOL-1263: load data for selected payment methods only

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -149,7 +149,6 @@
             <argument type="service" id="Kiener\MolliePayments\Factory\MollieApiFactory"/>
             <argument type="service" id="Kiener\MolliePayments\Service\SettingsService"/>
             <argument type="service" id="Kiener\MolliePayments\Repository\Language\LanguageRepository"/>
-            <argument type="service" id="Kiener\MolliePayments\Repository\Locale\LocaleRepository"/>
             <argument type="service" id="Kiener\MolliePayments\Service\MandateService"/>
             <argument type="service" id="Kiener\MolliePayments\Gateway\Mollie\MollieGateway"/>
             <tag name="kernel.event_subscriber"/>

--- a/src/Subscriber/CheckoutConfirmPageSubscriber.php
+++ b/src/Subscriber/CheckoutConfirmPageSubscriber.php
@@ -190,7 +190,7 @@ class CheckoutConfirmPageSubscriber implements EventSubscriberInterface
                 /** @var LanguageEntity $language */
                 $language = $languagesResult->first();
 
-                if ($language !== null) {
+                if ($language !== null && $language->getLocale() !== null) {
                     $locale = $language->getLocale()->getCode();
                 }
             }


### PR DESCRIPTION
Here were some Problems

1) ideal issues, pos terminal and credit card mandate were loaded on every request
2) profile id was loaded twice, one general and one for ideal issues

now:
1) we load only additional data if mollie payments were selected
2) the profile id is loaded once and saved for the request
3) ideal, pos, CC data is loaded if the payment methods are selected