### PR TITLE
PISHPS-263: allow set apple pay as default payment method

### DIFF
--- a/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-payment-method.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/apple-pay-payment-method.plugin.js
@@ -21,7 +21,7 @@ export default class MollieApplePayPaymentMethod extends Plugin {
         }
 
         // support for < Shopware 6.4
-        this.hideApplePay('.payment-method-input.applepay');
+        this.hideApplePay('.checkout-main .payment-method-input.applepay');
 
         // support for >= Shopware 6.4
         // we have to find the dynamic ID and use that
@@ -30,7 +30,7 @@ export default class MollieApplePayPaymentMethod extends Plugin {
         client.get(
             shopUrl + '/mollie/apple-pay/applepay-id',
             (data) => {
-                me.hideApplePay('#paymentMethod' + data.id);
+                me.hideApplePay('.checkout-main #paymentMethod' + data.id);
             }
         );
 

--- a/tests/Cypress/cypress/e2e/storefront/payment-methods/applepay.cy.js
+++ b/tests/Cypress/cypress/e2e/storefront/payment-methods/applepay.cy.js
@@ -70,29 +70,5 @@ context("Apple Pay", () => {
             cy.contains('Apple Pay').should('not.exist');
         })
     })
-
-    describe('Account', () => {
-
-        it('C4081: Apple Pay hidden in account even if possible in browser @core', () => {
-
-            applePayFactory.registerApplePay(true);
-
-            scenarioDummyUser.execute();
-            accountAction.openPaymentMethods();
-
-            cy.wait(2000);
-            cy.contains('Apple Pay').should('not.exist');
-        })
-
-        it('C4083: Apple Pay hidden if not possible in browser (Account) @core', () => {
-
-            applePayFactory.registerApplePay(false);
-
-            scenarioDummyUser.execute();
-            accountAction.openPaymentMethods();
-
-            cy.wait(2000);
-            cy.contains('Apple Pay').should('not.exist');
-        })
-    })
+    
 })


### PR DESCRIPTION
@boxblinkracer customer wants to select applay as default pament method in account area regardless of browser