### PR TITLE
Mol 1299/refund tax at net orders

### DIFF
--- a/src/Components/RefundManager/Builder/RefundDataBuilder.php
+++ b/src/Components/RefundManager/Builder/RefundDataBuilder.php
@@ -19,7 +19,9 @@ use Kiener\MolliePayments\Struct\Order\OrderAttributes;
 use Kiener\MolliePayments\Struct\OrderLineItemEntity\OrderLineItemEntityAttributes;
 use Mollie\Api\Resources\OrderLine;
 use Mollie\Api\Resources\Refund;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 
@@ -112,15 +114,19 @@ class RefundDataBuilder
                     $alreadyRefundedQty = $this->getRefundedQuantity($mollieOrderLineId, $mollieOrder, $refunds);
                 }
 
+                $taxTotal = round($this->calculateLineItemTaxTotal($item), 2);
+                $taxPerItem = floor($taxTotal / $item->getQuantity() * 100) / 100;
+                $taxDiff = round($taxTotal - ($taxPerItem * $item->getQuantity()), 2);
+
                 # this is just a way to move the promotions to the last positions of our array.
                 # also, shipping-free promotions have their discount item in the deliveries,...so here would just
                 # be a 0,00 value line item, that we want to skip.
                 if ($lineItemAttribute->isPromotion()) {
                     if ($item->getTotalPrice() !== 0.0) {
-                        $refundPromotionItems[] = PromotionItem::fromOrderLineItem($item, $alreadyRefundedQty);
+                        $refundPromotionItems[] = PromotionItem::fromOrderLineItem($item, $alreadyRefundedQty, $taxTotal, $taxPerItem, $taxDiff);
                     }
                 } else {
-                    $refundItems[] = new ProductItem($item, $promotionCompositions, $alreadyRefundedQty);
+                    $refundItems[] = new ProductItem($item, $promotionCompositions, $alreadyRefundedQty, $taxTotal, $taxPerItem, $taxDiff);
                 }
             }
         }
@@ -151,10 +157,14 @@ class RefundDataBuilder
                     $alreadyRefundedQty = $this->getRefundedQuantity($mollieLineID, $mollieOrder, $refunds);
                 }
 
+                $taxTotal = round($this->calculateDeliveryEntityTaxTotal($delivery), 2);
+                $taxPerItem = floor($taxTotal / $delivery->getShippingCosts()->getQuantity() * 100) / 100;
+                $taxDiff = round($taxTotal - ($taxPerItem * $delivery->getShippingCosts()->getQuantity()), 2);
+
                 if ($delivery->getShippingCosts()->getTotalPrice() < 0) {
-                    $refundPromotionItems[] = PromotionItem::fromOrderDeliveryItem($delivery, $alreadyRefundedQty);
+                    $refundPromotionItems[] = PromotionItem::fromOrderDeliveryItem($delivery, $alreadyRefundedQty, $taxTotal, $taxPerItem, $taxDiff);
                 } else {
-                    $refundDeliveryItems[] = new DeliveryItem($delivery, $alreadyRefundedQty);
+                    $refundDeliveryItems[] = new DeliveryItem($delivery, $alreadyRefundedQty, $taxTotal, $taxPerItem, $taxDiff);
                 }
             }
         }
@@ -178,6 +188,8 @@ class RefundDataBuilder
         # we first need products, then promotions and as last type we add the deliveries
         $refundItems = array_merge($refundItems, $refundPromotionItems, $refundDeliveryItems);
 
+        // get the tax status of the order
+        $taxStatus = $order->getTaxStatus();
 
         # now fetch some basic values from the API
         # TODO: these API calls should be removed one day, once I have more time (this refund manager is indeed huge) for now it's fine
@@ -205,7 +217,8 @@ class RefundDataBuilder
             $pendingRefundAmount,
             $refundedTotal,
             $remaining,
-            $roundingDiffTotal
+            $roundingDiffTotal,
+            $taxStatus
         );
     }
 
@@ -242,11 +255,45 @@ class RefundDataBuilder
 
         foreach ($order->getLineItems() as $item) {
             if (isset($item->getPayload()['composition'])) {
-                $promotionCompositions[] = $item->getPayload()['composition'];
+                $promotionComposition = $item->getPayload()['composition'];
+
+                $promotionComposition = $this->calculatePromotionCompositionTax($item, $promotionComposition);
+
+                $promotionCompositions[] = $promotionComposition;
             }
         }
 
         return $promotionCompositions;
+    }
+
+    /**
+     * @param OrderLineItemEntity $item
+     * @param array<int, mixed> $promotionComposition
+     * @return array<int, mixed>
+     */
+    private function calculatePromotionCompositionTax(OrderLineItemEntity $item, array $promotionComposition): array
+    {
+        $lineItemAttribute = new OrderLineItemEntityAttributes($item);
+        if ($lineItemAttribute->isPromotion()) {
+            $taxTotal = round($this->calculateLineItemTaxTotal($item), 2);
+            $lineItemTotal = $item->getTotalPrice();
+            $lastIndex = array_keys($promotionComposition)[count($promotionComposition) - 1];
+
+            $taxSum = 0;
+
+            foreach ($promotionComposition as $i => &$composition) {
+                $partialTax = round($taxTotal * $composition['discount'] / $lineItemTotal, 2);
+
+                if ($i === $lastIndex) {
+                    $partialTax = -$taxTotal - $taxSum;
+                }
+
+                $composition['taxValue'] = $partialTax;
+                $taxSum += $partialTax;
+            }
+        }
+
+        return $promotionComposition;
     }
 
     /**
@@ -311,5 +358,49 @@ class RefundDataBuilder
         }
 
         return $refundedQty;
+    }
+
+    /**
+     * @param OrderLineItemEntity $item
+     * @return float
+     */
+    private function calculateLineItemTaxTotal(OrderLineItemEntity $item): float
+    {
+        $taxTotal = 0;
+
+        $price = $item->getPrice();
+
+        if (!$price instanceof CalculatedPrice) {
+            return $taxTotal;
+        }
+
+        return $this->calculateTax($price);
+    }
+
+    /**
+     * @param OrderDeliveryEntity $delivery
+     * @return float
+     */
+    private function calculateDeliveryEntityTaxTotal(OrderDeliveryEntity $delivery): float
+    {
+        $shippingCosts = $delivery->getShippingCosts();
+
+        return $this->calculateTax($shippingCosts);
+    }
+
+    /**
+     * @param CalculatedPrice $price
+     * @return float
+     */
+    private function calculateTax(CalculatedPrice $price): float
+    {
+        $calculatedTaxes = $price->getCalculatedTaxes();
+        $taxTotal = 0;
+
+        foreach ($calculatedTaxes as $calculatedTax) {
+            $taxTotal += $calculatedTax->getTax();
+        }
+
+        return $taxTotal;
     }
 }

--- a/src/Components/RefundManager/RefundData/OrderItem/AbstractItem.php
+++ b/src/Components/RefundManager/RefundData/OrderItem/AbstractItem.php
@@ -5,6 +5,33 @@ namespace Kiener\MolliePayments\Components\RefundManager\RefundData\OrderItem;
 abstract class AbstractItem
 {
     /**
+     * @var float
+     */
+    private $taxTotal;
+
+    /**
+     * @var float
+     */
+    private $taxPerItem;
+
+    /**
+     * @var float
+     */
+    private $taxDiff;
+
+    /**
+     * @param float $taxTotal
+     * @param float $taxPerItem
+     * @param float $taxDiff
+     */
+    public function __construct(float $taxTotal, float $taxPerItem, float $taxDiff)
+    {
+        $this->taxTotal = $taxTotal;
+        $this->taxPerItem = $taxPerItem;
+        $this->taxDiff = $taxDiff;
+    }
+
+    /**
      * @param string $id
      * @param string $label
      * @param string $referenceNumber
@@ -15,10 +42,11 @@ abstract class AbstractItem
      * @param float $totalPrice
      * @param float $promotionDiscount
      * @param int $promotionAffectedQty
+     * @param float $promotionTaxValue
      * @param int $refundedQty
      * @return array<mixed>
      */
-    protected function buildArray(string $id, string $label, string $referenceNumber, bool $isPromotion, bool $isDelivery, float $unitPrice, int $quantity, float $totalPrice, float $promotionDiscount, int $promotionAffectedQty, int $refundedQty): array
+    protected function buildArray(string $id, string $label, string $referenceNumber, bool $isPromotion, bool $isDelivery, float $unitPrice, int $quantity, float $totalPrice, float $promotionDiscount, int $promotionAffectedQty, float $promotionTaxValue, int $refundedQty): array
     {
         return [
             'refunded' => $refundedQty,
@@ -33,9 +61,15 @@ abstract class AbstractItem
                 'promotion' => [
                     'discount' => $promotionDiscount,
                     'quantity' => $promotionAffectedQty,
+                    'taxValue' => $promotionTaxValue,
                 ],
                 'isPromotion' => $isPromotion,
                 'isDelivery' => $isDelivery,
+                'tax' => [
+                    'totalItemTax' => round($this->taxTotal, 2),
+                    'perItemTax' => round($this->taxPerItem, 2),
+                    'totalToPerItemRoundingDiff' => round($this->taxDiff, 2),
+                ],
             ],
         ];
     }

--- a/src/Components/RefundManager/RefundData/OrderItem/DeliveryItem.php
+++ b/src/Components/RefundManager/RefundData/OrderItem/DeliveryItem.php
@@ -23,11 +23,16 @@ class DeliveryItem extends AbstractItem
     /**
      * @param OrderDeliveryEntity $delivery
      * @param int $alreadyRefundedQuantity
+     * @param float $taxTotal
+     * @param float $taxPerItem
+     * @param float $taxDiff
      */
-    public function __construct(OrderDeliveryEntity $delivery, int $alreadyRefundedQuantity)
+    public function __construct(OrderDeliveryEntity $delivery, int $alreadyRefundedQuantity, float $taxTotal, float $taxPerItem, float $taxDiff)
     {
         $this->delivery = $delivery;
         $this->alreadyRefundedQty = $alreadyRefundedQuantity;
+
+        parent::__construct($taxTotal, $taxPerItem, $taxDiff);
     }
 
 
@@ -47,6 +52,7 @@ class DeliveryItem extends AbstractItem
             $this->delivery->getShippingCosts()->getUnitPrice(),
             $this->delivery->getShippingCosts()->getQuantity(),
             $this->delivery->getShippingCosts()->getTotalPrice(),
+            0,
             0,
             0,
             $this->alreadyRefundedQty

--- a/src/Components/RefundManager/RefundData/OrderItem/ProductItem.php
+++ b/src/Components/RefundManager/RefundData/OrderItem/ProductItem.php
@@ -22,6 +22,11 @@ class ProductItem extends AbstractItem
     private $promotionAffectedQuantity;
 
     /**
+     * @var float
+     */
+    private $promotionTaxValue;
+
+    /**
      * @var int
      */
     private $alreadyRefundedQty;
@@ -31,13 +36,18 @@ class ProductItem extends AbstractItem
      * @param OrderLineItemEntity $lineItem
      * @param array<mixed> $promotionCompositions
      * @param int $alreadyRefundedQuantity
+     * @param float $taxTotal
+     * @param float $taxPerItem
+     * @param float $taxDiff
      */
-    public function __construct(OrderLineItemEntity $lineItem, array $promotionCompositions, int $alreadyRefundedQuantity)
+    public function __construct(OrderLineItemEntity $lineItem, array $promotionCompositions, int $alreadyRefundedQuantity, float $taxTotal, float $taxPerItem, float $taxDiff)
     {
         $this->lineItem = $lineItem;
         $this->alreadyRefundedQty = $alreadyRefundedQuantity;
 
         $this->extractPromotionDiscounts($promotionCompositions);
+
+        parent::__construct($taxTotal, $taxPerItem, $taxDiff);
     }
 
     /**
@@ -48,6 +58,7 @@ class ProductItem extends AbstractItem
     {
         $this->promotionDiscount = 0;
         $this->promotionAffectedQuantity = 0;
+        $this->promotionTaxValue = 0;
 
         foreach ($promotionCompositions as $composition) {
             foreach ($composition as $compItem) {
@@ -56,6 +67,7 @@ class ProductItem extends AbstractItem
                 if ($compItem['id'] === $this->lineItem->getReferencedId()) {
                     $this->promotionDiscount += round((float)$compItem['discount'], 2);
                     $this->promotionAffectedQuantity += (int)$compItem['quantity'];
+                    $this->promotionTaxValue += round((float)$compItem['taxValue'], 2);
                 }
             }
         }
@@ -77,6 +89,7 @@ class ProductItem extends AbstractItem
             $this->lineItem->getTotalPrice(),
             $this->promotionDiscount,
             $this->promotionAffectedQuantity,
+            $this->promotionTaxValue,
             $this->alreadyRefundedQty
         );
     }

--- a/src/Components/RefundManager/RefundData/OrderItem/PromotionItem.php
+++ b/src/Components/RefundManager/RefundData/OrderItem/PromotionItem.php
@@ -27,8 +27,11 @@ class PromotionItem extends AbstractItem
     /**
      * @param OrderDeliveryEntity|OrderLineItemEntity $lineItem
      * @param int $alreadyRefundedQuantity
+     * @param float $taxTotal
+     * @param float $taxPerItem
+     * @param float $taxDiff
      */
-    private function __construct($lineItem, int $alreadyRefundedQuantity)
+    private function __construct($lineItem, int $alreadyRefundedQuantity, float $taxTotal, float $taxPerItem, float $taxDiff)
     {
         if ($lineItem instanceof OrderDeliveryEntity) {
             $this->orderDeliveryItem = $lineItem;
@@ -39,26 +42,34 @@ class PromotionItem extends AbstractItem
         }
 
         $this->alreadyRefundedQty = $alreadyRefundedQuantity;
+
+        parent::__construct($taxTotal, $taxPerItem, $taxDiff);
     }
 
     /**
      * @param OrderLineItemEntity $lineItem
      * @param int $alreadyRefundedQuantity
+     * @param float $taxTotal
+     * @param float $taxPerItem
+     * @param float $taxDiff
      * @return PromotionItem
      */
-    public static function fromOrderLineItem(OrderLineItemEntity $lineItem, int $alreadyRefundedQuantity)
+    public static function fromOrderLineItem(OrderLineItemEntity $lineItem, int $alreadyRefundedQuantity, float $taxTotal, float $taxPerItem, float $taxDiff)
     {
-        return new PromotionItem($lineItem, $alreadyRefundedQuantity);
+        return new PromotionItem($lineItem, $alreadyRefundedQuantity, $taxTotal, $taxPerItem, $taxDiff);
     }
 
     /**
      * @param OrderDeliveryEntity $lineItem
      * @param int $alreadyRefundedQuantity
+     * @param float $taxTotal
+     * @param float $taxPerItem
+     * @param float $taxDiff
      * @return PromotionItem
      */
-    public static function fromOrderDeliveryItem(OrderDeliveryEntity $lineItem, int $alreadyRefundedQuantity)
+    public static function fromOrderDeliveryItem(OrderDeliveryEntity $lineItem, int $alreadyRefundedQuantity, float $taxTotal, float $taxPerItem, float $taxDiff)
     {
-        return new PromotionItem($lineItem, $alreadyRefundedQuantity);
+        return new PromotionItem($lineItem, $alreadyRefundedQuantity, $taxTotal, $taxPerItem, $taxDiff);
     }
 
     /**
@@ -76,6 +87,7 @@ class PromotionItem extends AbstractItem
                 $this->orderLineItem->getUnitPrice(),
                 $this->orderLineItem->getQuantity(),
                 $this->orderLineItem->getTotalPrice(),
+                0,
                 0,
                 0,
                 $this->alreadyRefundedQty
@@ -101,6 +113,7 @@ class PromotionItem extends AbstractItem
                 $this->orderDeliveryItem->getShippingCosts()->getTotalPrice(),
                 $this->orderDeliveryItem->getShippingCosts()->getQuantity(),
                 $this->orderDeliveryItem->getShippingCosts()->getTotalPrice(),
+                0,
                 0,
                 0,
                 $this->alreadyRefundedQty

--- a/src/Components/RefundManager/RefundData/RefundData.php
+++ b/src/Components/RefundManager/RefundData/RefundData.php
@@ -45,6 +45,11 @@ class RefundData
     private $roundingItemTotal;
 
     /**
+     * @var string
+     */
+    private $taxStatus;
+
+    /**
      * @param AbstractItem[] $cartItems
      * @param Refund[] $refunds
      * @param float $amountVouchers
@@ -53,7 +58,7 @@ class RefundData
      * @param float $amountRemaining
      * @param float $roundingItemTotal
      */
-    public function __construct(array $cartItems, array $refunds, float $amountVouchers, float $amountPendingRefunds, float $amountCompletedRefunds, float $amountRemaining, float $roundingItemTotal)
+    public function __construct(array $cartItems, array $refunds, float $amountVouchers, float $amountPendingRefunds, float $amountCompletedRefunds, float $amountRemaining, float $roundingItemTotal, string $taxStatus)
     {
         $this->orderItems = $cartItems;
         $this->refunds = $refunds;
@@ -62,6 +67,7 @@ class RefundData
         $this->amountCompletedRefunds = $amountCompletedRefunds;
         $this->amountRemaining = $amountRemaining;
         $this->roundingItemTotal = $roundingItemTotal;
+        $this->taxStatus = $taxStatus;
     }
 
     /**
@@ -120,6 +126,14 @@ class RefundData
         return $this->roundingItemTotal;
     }
 
+    /**
+     * @return string
+     */
+    public function getTaxStatus(): string
+    {
+        return $this->taxStatus;
+    }
+
 
     /**
      * @return array<mixed>
@@ -155,6 +169,7 @@ class RefundData
             ],
             'cart' => $hydratedOrderItems,
             'refunds' => $refundsArray,
+            'taxStatus' => $this->taxStatus,
         ];
     }
 }

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/grids/ShopwareOrderGrid.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/grids/ShopwareOrderGrid.js
@@ -61,6 +61,11 @@ export default class ShopwareOrderGrid {
             },
             {
                 label: '',
+                property: 'inputConsiderTax',
+                align: 'center',
+            },
+            {
+                label: '',
                 property: 'inputConsiderPromotion',
                 align: 'center',
             },

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/index.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/index.js
@@ -201,6 +201,13 @@ Component.register('mollie-refund-manager', {
         },
 
         /**
+         * Gets if the order tax status is gross
+         */
+        isTaxStatusGross() {
+            return this.order.taxStatus === 'gross';
+        },
+
+        /**
          * This automatically selects all items by
          * assigning their maximum quantity to be refunded.
          * We iterate through all items and just mark them
@@ -257,6 +264,17 @@ Component.register('mollie-refund-manager', {
          */
         onItemAmountChanged(item) {
             this.itemService.onAmountChanged(item);
+            this._calculateFinalAmount();
+        },
+
+        /**
+         * This will be executed if the user changes the
+         * configuration to either activate or deactivate the
+         * Tax Refund in case of Net Orders.
+         * @param item
+         */
+        onItemRefundTaxChanged(item) {
+            this.itemService.onRefundTaxChanged(item);
             this._calculateFinalAmount();
         },
 

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/mollie-refund-manager.html.twig
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/mollie-refund-manager.html.twig
@@ -85,6 +85,17 @@
                         {{ item.refundAmount | currency(order.currency.shortName) }}
                     </div>
                 </template>
+                <template #column-inputConsiderTax="{ item }">
+                    <div v-if="isItemRefundable(item) && !isTaxStatusGross()">
+                        <sw-checkbox-field :label="$tc('mollie-payments.refund-manager.cart.grid.checkRefundTax')"
+                                           v-model="item.refundTax"
+                                           class="check-refund-tax"
+                                           :class="{ 'tutorial-active': tutorialPartialPromotionsVisible }"
+                                           @change="onItemRefundTaxChanged(item)"
+                                        >
+                        </sw-checkbox-field>
+                    </div>
+                </template>
                 <template #column-inputConsiderPromotion="{ item }">
                     <div v-if="isItemRefundable(item) && !isItemPromotion(item) && isItemDiscounted(item)">
                         <sw-checkbox-field :label="$tc('mollie-payments.refund-manager.cart.grid.checkDeductPromotion')"

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/mollie-refund-manager.scss
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/mollie-refund-manager.scss
@@ -95,7 +95,8 @@
             }
         }
 
-        .check-deduct-promotion {
+        .check-deduct-promotion,
+        .check-refund-tax {
             label {
                 font-size: 12px;
             }

--- a/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/services/RefundItemService.js
+++ b/src/Resources/app/administration/src/module/mollie-payments/components/mollie-refund-manager/services/RefundItemService.js
@@ -214,13 +214,6 @@ export default class RefundItemService {
             if (item.refundQuantity > 0 && item.refundQuantity + item.refunded === item.shopware.quantity) {
                 refundTaxAmount += item.shopware.tax.totalToPerItemRoundingDiff;
             }
-        }
-
-        if (item.refundPromotion) {
-            // we have to calculate the amount of a single item, because
-            // the promotion discount is the full discount on all of these items.
-            const discountPerQty = item.shopware.promotion.discount / item.shopware.promotion.quantity;
-            const discount = (item.refundQuantity * discountPerQty);
             const promotionTaxValuePerQty = item.shopware.promotion.taxValue / item.shopware.promotion.quantity;
 
             let promotionTaxValue = 0;
@@ -228,8 +221,16 @@ export default class RefundItemService {
                 promotionTaxValue = promotionTaxValuePerQty * item.refundQuantity;
             }
 
-            item.refundAmount = newRefundAmount + refundTaxAmount - discount - promotionTaxValue;
+            refundTaxAmount -= promotionTaxValue;
+        }
 
+        if (item.refundPromotion) {
+            // we have to calculate the amount of a single item, because
+            // the promotion discount is the full discount on all of these items.
+            const discountPerQty = item.shopware.promotion.discount / item.shopware.promotion.quantity;
+            const discount = (item.refundQuantity * discountPerQty);
+
+            item.refundAmount = newRefundAmount + refundTaxAmount - discount;
         } else {
             item.refundAmount = newRefundAmount + refundTaxAmount;
         }

--- a/src/Resources/app/administration/src/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/snippet/de-DE.json
@@ -160,7 +160,8 @@
             "resetStock": "Lagerbestand zurücksetzen"
           },
           "btnResetLine": "Zeile zurücksetzen",
-          "checkDeductPromotion": "Rabatt abziehen"
+          "checkDeductPromotion": "Rabatt abziehen",
+          "checkRefundTax": "BTW terugbetalen"
         },
         "roundDiffItemAdded": "Automatische Position für Rundungen wurde hinzugefügt"
       },

--- a/src/Resources/app/administration/src/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/snippet/en-GB.json
@@ -160,7 +160,8 @@
             "resetStock": "Reset Stock"
           },
           "btnResetLine": "Reset Line",
-          "checkDeductPromotion": "Deduct promotion"
+          "checkDeductPromotion": "Deduct promotion",
+          "checkRefundTax": "Refund VAT"
         },
         "roundDiffItemAdded": "Automatic rounding item was added"
       },

--- a/src/Resources/app/administration/src/snippet/nl-NL.json
+++ b/src/Resources/app/administration/src/snippet/nl-NL.json
@@ -160,7 +160,8 @@
             "resetStock": "Voorraad resetten"
           },
           "btnResetLine": "Rij resetten",
-          "checkDeductPromotion": "Promotie aftrekken"
+          "checkDeductPromotion": "Promotie aftrekken",
+          "checkRefundTax": "Refund VAT"
         },
         "roundDiffItemAdded": "Automatisch afrondingsitem toegevoegd"
       },

--- a/tests/PHPUnit/Components/RefundManager/RefundData/OrderItem/ProductItemTest.php
+++ b/tests/PHPUnit/Components/RefundManager/RefundData/OrderItem/ProductItemTest.php
@@ -46,7 +46,7 @@ class ProductItemTest extends TestCase
      */
     public function testToArray(): void
     {
-        $refundManagerItem = new ProductItem($this->lineItem, [], 0);
+        $refundManagerItem = new ProductItem($this->lineItem, [], 0, 1.23, 2.34, 3.45);
 
         $expected = [
             'refunded' => 0,
@@ -61,9 +61,15 @@ class ProductItemTest extends TestCase
                 'promotion' => [
                     'discount' => 0,
                     'quantity' => 0,
+                    'taxValue' => 0,
                 ],
                 'isPromotion' => false,
                 'isDelivery' => false,
+                'tax' => [
+                    'totalItemTax' => 1.23,
+                    'perItemTax' => 2.34,
+                    'totalToPerItemRoundingDiff' => 3.45,
+                ],
             ],
         ];
 

--- a/tests/PHPUnit/Components/RefundManager/RefundData/RefundDataTest.php
+++ b/tests/PHPUnit/Components/RefundManager/RefundData/RefundDataTest.php
@@ -19,7 +19,7 @@ class RefundDataTest extends TestCase
      */
     public function testTotalValues()
     {
-        $data = new RefundData([], [], 5, 2, 6, 9, 1.45);
+        $data = new RefundData([], [], 5, 2, 6, 9, 1.45, 'gross');
 
         $expected = [
             'totals' => [
@@ -31,6 +31,7 @@ class RefundDataTest extends TestCase
             ],
             'cart' => [],
             'refunds' => [],
+            'taxStatus' => 'gross'
         ];
 
         $this->assertEquals($expected, $data->toArray());
@@ -55,9 +56,9 @@ class RefundDataTest extends TestCase
         $lineItem->setReferencedId('product-id-1');
         $lineItem->setPayload(['productNumber' => 'P123']);
 
-        $items[] = new ProductItem($lineItem, [], 2);
+        $items[] = new ProductItem($lineItem, [], 2, '1.233', '2.343', '3.453');
 
-        $data = new RefundData($items, [], 0, 0, 0, 0, 0);
+        $data = new RefundData($items, [], 0, 0, 0, 0, 0, 'gross');
 
         $expected = [
             [
@@ -73,9 +74,15 @@ class RefundDataTest extends TestCase
                     'promotion' => [
                         'discount' => 0.0,
                         'quantity' => 0,
+                        'taxValue' => 0.0,
                     ],
                     'isPromotion' => false,
                     'isDelivery' => false,
+                    'tax' => [
+                        'totalItemTax' => 1.23,
+                        'perItemTax' => 2.34,
+                        'totalToPerItemRoundingDiff' => 3.45,
+                    ],
                 ],
             ]
         ];
@@ -96,7 +103,7 @@ class RefundDataTest extends TestCase
 
         $refunds[] = [];
 
-        $data = new RefundData([], $refunds, 0, 0, 0, 0, 0);
+        $data = new RefundData([], $refunds, 0, 0, 0, 0, 0, 'gross');
 
         $this->assertCount(1, $data->toArray()['refunds']);
     }


### PR DESCRIPTION
Add Flag to Refund Manager to automatically calculate Item Refund Value incl. VAT
This Flag is default off to not change default Behavior
This Flag also includes the Promotion VATs in the calculation, so that not more VAT is refunded than paid (as the promotion lowers the paid VAT)