### PR TITLE
Fix namespace separator in polyfill classes

### DIFF
--- a/polyfill/Shopware/Core/Checkout/Payment/Exception/PaymentProcessException.php
+++ b/polyfill/Shopware/Core/Checkout/Payment/Exception/PaymentProcessException.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 namespace Shopware\Core\Checkout\Payment\Exception;
-if (class_exists(__NAMESPACE__ . '/PaymentProcessException')) {
+if (class_exists(__NAMESPACE__ . '\\PaymentProcessException')) {
     return;
 }
 use Shopware\Core\Framework\Log\Package;

--- a/polyfill/Shopware/Core/Checkout/Payment/PaymentException.php
+++ b/polyfill/Shopware/Core/Checkout/Payment/PaymentException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Shopware\Core\Checkout\Payment;
 
 
-if (class_exists(__NAMESPACE__ . '/PaymentException')) {
+if (class_exists(__NAMESPACE__ . '\\PaymentException')) {
     return;
 }
 

--- a/polyfill/Shopware/Core/Framework/Event/BusinessEventInterface.php
+++ b/polyfill/Shopware/Core/Framework/Event/BusinessEventInterface.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Framework\Event;
 
-if (interface_exists(__NAMESPACE__ . '/BusinessEventInterface')) {
+if (interface_exists(__NAMESPACE__ . '\\BusinessEventInterface')) {
     return;
 }
 

--- a/polyfill/Shopware/Core/Framework/Event/CustomerAware.php
+++ b/polyfill/Shopware/Core/Framework/Event/CustomerAware.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Framework\Event;
 
-if (interface_exists(__NAMESPACE__ . '/CustomerAware')) {
+if (interface_exists(__NAMESPACE__ . '\\CustomerAware')) {
     return;
 }
 

--- a/polyfill/Shopware/Core/Framework/Event/FlowEventAware.php
+++ b/polyfill/Shopware/Core/Framework/Event/FlowEventAware.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Shopware\Core\Framework\Event;
 
-if (interface_exists(__NAMESPACE__ . '/FlowEventAware')) {
+if (interface_exists(__NAMESPACE__ . '\\FlowEventAware')) {
     return;
 }
 

--- a/polyfill/Shopware/Core/Framework/Event/MailAware.php
+++ b/polyfill/Shopware/Core/Framework/Event/MailAware.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Framework\Event;
 
-if (interface_exists(__NAMESPACE__ . '/MailAware')) {
+if (interface_exists(__NAMESPACE__ . '\\MailAware')) {
     return;
 }
 

--- a/polyfill/Shopware/Core/Framework/Event/OrderAware.php
+++ b/polyfill/Shopware/Core/Framework/Event/OrderAware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Shopware\Core\Framework\Event;
 
 
-if (interface_exists(__NAMESPACE__.'/OrderAware')) {
+if (interface_exists(__NAMESPACE__.'\\OrderAware')) {
     return;
 }
 

--- a/polyfill/Shopware/Core/System/Snippet/Files/AbstractSnippetFile.php
+++ b/polyfill/Shopware/Core/System/Snippet/Files/AbstractSnippetFile.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\System\Snippet\Files;
 
 
-if (class_exists(__NAMESPACE__.'/AbstractSnippetFile')) {
+if (class_exists(__NAMESPACE__.'\\AbstractSnippetFile')) {
     return;
 }
 

--- a/polyfill/Shopware/Core/System/Snippet/Files/SnippetFileInterface.php
+++ b/polyfill/Shopware/Core/System/Snippet/Files/SnippetFileInterface.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\System\Snippet\Files;
 
 
-if (interface_exists(__NAMESPACE__.'/SnippetFileInterface')) {
+if (interface_exists(__NAMESPACE__.'\\SnippetFileInterface')) {
     return;
 }
 


### PR DESCRIPTION
A wrong class_exists call using a slash as namespace separator causing issues. The conditions are always false, regardless the Shopware classes exist.