### PR TITLE
fix: load order delivery state machine state

### DIFF
--- a/src/Service/OrderDeliveryService.php
+++ b/src/Service/OrderDeliveryService.php
@@ -28,6 +28,7 @@ class OrderDeliveryService
         $criteria = new Criteria([$orderDeliveryId]);
         $criteria->addAssociation('order.transactions.paymentMethod');
         $criteria->addAssociation('order.deliveries.shippingMethod');
+        $criteria->addAssociation('order.deliveries.stateMachineState');
         $criteria->addAssociation('shippingMethod');
         $result = $this->orderDeliveryRepository->search($criteria, $context);
 


### PR DESCRIPTION
The change adds loading of the state-machine state to the loading of the order in `OrderDeliveryService`.
This is necessary, because otherwise the technical name of the state machine state can't be loaded here: https://github.com/mollie/Shopware6/blob/9558e0de87d0bc43190ae69242e9b1d77eb3e47b/src/Service/Transition/DeliveryTransitionService.php#L92 

This leeds to two delivery-state transitions: from shipped to open (see line 106) and then back to shipped (l. 109).
The second and third marked transition in the screenshot are caused by this bug.
![Bildschirmfoto 2024-08-05 um 14 05 52](https://github.com/user-attachments/assets/03a5b069-6cd5-418e-8b4b-26a924fc0b9c)

I patched the file like in this PR, now it's working as intended 