### PR TITLE
use more specific way to check if a backup cart is existing

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -130,6 +130,7 @@
 
         <service id="Kiener\MolliePayments\Service\Cart\CartBackupService" class="Kiener\MolliePayments\Service\Cart\CartBackupService" public="true">
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartPersister"/>
         </service>
 
         <service id="Kiener\MolliePayments\Service\Mollie\OrderStatusConverter" public="false">

--- a/src/Service/Cart/CartBackupService.php
+++ b/src/Service/Cart/CartBackupService.php
@@ -19,13 +19,18 @@ class CartBackupService
      */
     private $cartService;
 
+    /**
+     * @var AbstractCartPerister 
+     */
+    private $cartPersister;
 
     /**
      * @param CartService $cartService
      */
-    public function __construct(CartService $cartService)
+    public function __construct(CartService $cartService, AbstractCartPerister $cartPersister)
     {
         $this->cartService = $cartService;
+        $this->cartPersister = $cartPersister;
     }
 
 
@@ -35,9 +40,12 @@ class CartBackupService
      */
     public function isBackupExisting(SalesChannelContext $context): bool
     {
-        $backupCart = $this->cartService->getCart(self::BACKUP_TOKEN, $context);
-
-        return ($backupCart->getLineItems()->count() > 0);
+        try {
+            $backupCart = $this->cartPersister->load(self::BACKUP_TOKEN, $context);
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
We're having problems with the loading behavior of the `Kiener\MolliePayments\Service\Cart\CartBackupService`. Our plugin is dynamically adding an additional `LineItem` to the current cart using a custom `Collector`. However, the `LineItem` is also being added to the backup cart which leads to the problem that `isBackupExisting` returns `true` without an existing backup cart. 

It would be good if the Mollie extension could use a more specific method to check if a backup cart exists. I would suggest the use of `Shopware\Core\Checkout\Cart\CartPersister::load(string $token, SalesChannelContext $context), see this pull request.