### PR TITLE
NTR - optimizes custom domain overwrite

### DIFF
--- a/src/Service/Router/RoutingBuilder.php
+++ b/src/Service/Router/RoutingBuilder.php
@@ -253,9 +253,7 @@ class RoutingBuilder
         # then always use this one and override existing ones
         if ($customDomain !== '') {
             $components = parse_url($url);
-            $host = (is_array($components) && isset($components['host'])) ? (string)$components['host'] : '';
-            # replace old domain with new custom domain
-            $url = str_replace($host, $customDomain, $url);
+            $url = $customDomain . ($components['path'] ?? '');
         }
 
         return $url;

--- a/tests/PHPUnit/Service/Routing/RoutingBuilderTest.php
+++ b/tests/PHPUnit/Service/Routing/RoutingBuilderTest.php
@@ -57,7 +57,7 @@ class RoutingBuilderTest extends TestCase
         # prepare our fake server data
         # assign a current domain to replace.
         # also configure our environment variable
-        $builder = $this->createBuilder('https://local.mollie.shop/notify/123', '123.eu.ngrok.io');
+        $builder = $this->createBuilder('https://local.mollie.shop/notify/123', 'https://123.eu.ngrok.io');
 
         $url = $builder->buildWebhookURL('-');
 


### PR DESCRIPTION
I would suggest adapting the `applyCustomDomain` method to replace not just the host but the full base URL. This way you can also control the schema as well as any ports. 

In the current implementation you might run into the problem that you have a local port like `8000` which is not the case for the URL you want to replace it with. Then only the host is replaced, and Mollie will still try to access the new host on port `8000`, which is not what you want.

This changes the behaviour of the `MOLLIE_SHOP_DOMAIN` env variable a bit, because it should provide a schema. But it's not necessary.