### PR TITLE
NTR: avoid misleading logs in payment remover route detection. fix #563

### DIFF
--- a/src/Service/Payment/Remover/CartAwareRouteInterface.php
+++ b/src/Service/Payment/Remover/CartAwareRouteInterface.php
@@ -12,7 +12,7 @@ interface CartAwareRouteInterface
         'store-api.payment.method',
     ];
 
-    public function isCartRoute(string $route = ""): bool;
+    public function isCartRoute(): bool;
 
     public function getCart(\Shopware\Core\System\SalesChannel\SalesChannelContext $context): \Shopware\Core\Checkout\Cart\Cart;
 }

--- a/src/Service/Payment/Remover/OrderAwareRouteInterface.php
+++ b/src/Service/Payment/Remover/OrderAwareRouteInterface.php
@@ -8,7 +8,7 @@ interface OrderAwareRouteInterface
         'frontend.account.edit-order.page',
     ];
 
-    public function isOrderRoute(string $route = ""): bool;
+    public function isOrderRoute(): bool;
 
     public function getOrder(\Shopware\Core\Framework\Context $context): \Shopware\Core\Checkout\Order\OrderEntity;
 }


### PR DESCRIPTION
so we had the problem of /atom.xml leading into exceptions and logs (bing-bot)

somehow it seems as if custom configurations lead to resolving of routes that shouldnt be resolved

then i think a bot detection or anything like this could lead to the route attribute being missing

nevertheless....our main goal here is just check if the route matching our expected cart or order routes
in that case it actually does not

so i think we should not have an impact in the exception chain in this case

so ive changed to fail-safe approaches

also removed the optional parameters because that leads to additional complexity and intertwining