### PR TITLE
Readd ARRAY_PARAM_OFFSET for parameter types in Elasticsearch indexers

### DIFF
--- a/src/Components/RefundManager/Elasticsearch/RefundAdminSearchIndexer.php
+++ b/src/Components/RefundManager/Elasticsearch/RefundAdminSearchIndexer.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Kiener\MolliePayments\Components\RefundManager\Elasticsearch;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Kiener\MolliePayments\Components\RefundManager\DAL\Refund\RefundCollection;
@@ -83,7 +84,7 @@ class RefundAdminSearchIndexer extends AbstractAdminIndexer
                 'ids' => Uuid::fromHexToBytesList($ids),
             ],
             [
-                'ids' => ParameterType::BINARY, // elasticsearch below 6.6 install old doctrine dbal where binary type does not exists yet
+                'ids' => ParameterType::BINARY + Connection::ARRAY_PARAM_OFFSET // elasticsearch below 6.6 install old doctrine dbal where binary type does not exists yet
             ]
         );
 

--- a/src/Components/RefundManager/Elasticsearch/RefundAdminSearchIndexer.php
+++ b/src/Components/RefundManager/Elasticsearch/RefundAdminSearchIndexer.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Kiener\MolliePayments\Components\RefundManager\Elasticsearch;
 
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Kiener\MolliePayments\Components\RefundManager\DAL\Refund\RefundCollection;

--- a/src/Components/Subscription/Elasticsearch/SubscriptionAdminSearchIndexer.php
+++ b/src/Components/Subscription/Elasticsearch/SubscriptionAdminSearchIndexer.php
@@ -88,7 +88,7 @@ class SubscriptionAdminSearchIndexer extends AbstractAdminIndexer
                 'ids' => Uuid::fromHexToBytesList($ids),
             ],
             [
-                'ids' => ParameterType::BINARY, //  elasticsearch below 6.6 install old doctrine dbal where binary type does not exists yet
+                'ids' => ParameterType::BINARY + Connection::ARRAY_PARAM_OFFSET, //  elasticsearch below 6.6 install old doctrine dbal where binary type does not exists yet
             ]
         );
 


### PR DESCRIPTION
In v4.16.0 the array parameter offsets have been removed in the elasticsearch indexers.

- https://github.com/mollie/Shopware6/commit/af21146c500e3979be76b92e527e820275e70381#diff-d26dc687e8718b20bb95e47a76628023bbd0a3fa1de054c40ebaf3c0cbedfb39R86
- https://github.com/mollie/Shopware6/commit/af21146c500e3979be76b92e527e820275e70381#diff-cac2b867b0145eb6b7f855a93f5a2debd2751fdbd476e0ec068f3cfb37c3b58eR91

Due to this change the `bin/console dal:refresh:index` command fails with an `ErrorException`:

```
[ErrorException]                     
Warning: Array to string conversion 
```

This PR readds the the parameter offsets via `Doctrine\DBAL\Connection::ARRAY_PARAM_OFFSET` constant.
