### PR TITLE
NTR: fix typo in run-e2e GitHub Action description

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -31,7 +31,7 @@ inputs:
     default: ''
     required: false
   REMOVE_DEPRECATED_TESTS:
-    description: "If enabled, tests that are marked es deprecated will be removed"
+    description: "If enabled, tests that are marked as deprecated will be removed"
     default: 'false'
     required: false
   CYPRESS_RESULTS_SUFFIX:


### PR DESCRIPTION
### What has been changed
Fixed a small typo in the description field of `.github/actions/run-e2e/action.yml`:
> "marked es deprecated" → "marked as deprecated"

### Why
This change only corrects a spelling mistake in a comment/description.  
No functional or behavioral changes are introduced.

### Checklist
- [x] Verified YAML syntax
- [x] No code logic affected
- [x] `make pr` passes locally