### PR TITLE
Update the ApplePayDomainVerificationService for compatibility reasons.

### DIFF
--- a/src/Components/ApplePayDirect/Services/ApplePayDomainVerificationService.php
+++ b/src/Components/ApplePayDirect/Services/ApplePayDomainVerificationService.php
@@ -48,11 +48,14 @@ class ApplePayDomainVerificationService
         if ($response->getStatusCode() < Response::HTTP_OK || $response->getStatusCode() >= Response::HTTP_MULTIPLE_CHOICES) {
             return;
         }
+        
+        try {
+            if ($this->filesystem->has(self::LOCAL_FILE)) {
+                $this->filesystem->delete(self::LOCAL_FILE);
+            }
 
-        if ($this->filesystem->fileExists(self::LOCAL_FILE)) {
-            $this->filesystem->delete(self::LOCAL_FILE);
+            $this->filesystem->write(self::LOCAL_FILE, $response->getBody(), ['ContentType' => 'text/plain']);
+        } catch (\Throwable $e) {
         }
-
-        $this->filesystem->write(self::LOCAL_FILE, $response->getBody(), ['ContentType' => 'text/plain']);
     }
 }


### PR DESCRIPTION
we are using sirv.com as our S3 compatible cloud storage for media files. 
with these changes it should be possible to have local file storage as s3 file storage as an storage adapter

using the older fileExists function is more compatible with the flysystem-async-aws-s3

also added a config array to the write function as autodetermination of the mimetype for the apple-developer-merchantid-domain-association file is not working well.

please see https://github.com/mollie/Shopware6/issues/333 as an additional problem description. 
