### PR TITLE
Normalize phone numbers to E.164 instead of dropping them, cover handler-set numbers

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -4,7 +4,7 @@
 - Behoben: Bei der Rückkehr von der Bezahlseite erscheint kein Token-Fehler mehr, wenn die Zahlung bereits abgeschlossen war. Kunden werden je nach Zahlungsstatus zur Bestätigungs- oder Bestellbearbeitungsseite geleitet.
 - Behoben: Der Mollie-Bestell-Tab stürzt auf Shopware-Versionen, die die Bestelldetailseite nicht als Pinia-Store registrieren, nicht mehr ab.
 - Behoben: Der automatische Versand löst keinen Mollie-API-Aufruf mehr für Bestellungen aus, die nicht mit Mollie bezahlt wurden.
-- Behoben: Eine ungültige Telefonnummer in der Adresse lässt die Zahlung nicht mehr fehlschlagen.
+- Behoben: Eine ungültige Telefonnummer in der Adresse lässt die Zahlung nicht mehr fehlschlagen. Nummern im nationalen Format werden nun nach E.164 normalisiert (auch für Bancomat Pay / Bizum eingegebene Nummern); nicht normalisierbare Nummern werden aus dem Payload entfernt.
 - Behoben: Zahlungen schlagen nicht mehr fehl, wenn der Name der Versandart leer ist. Als Ersatz wird „Shipping" verwendet.
 - Behoben: Plugin-Updates schlagen auf Shopware 6.5 nicht mehr mit einem 500er-Fehler fehl.
 - Behoben: Die Storefront bricht auf Shopware 6.5 nicht mehr mit dem Fehler „Plugin is already registered" ab.

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -4,7 +4,7 @@
 - Fixed: Returning from the payment page no longer shows a token error when the payment was already completed. Customers are now sent to the confirmation or edit-order page based on the payment status.
 - Fixed: The Mollie order tab no longer crashes on Shopware versions that don't register the order detail as a Pinia store.
 - Fixed: Automatic shipment no longer triggers a Mollie API call for orders that were not paid with Mollie.
-- Fixed: An invalid phone number in the address no longer makes the payment fail.
+- Fixed: An invalid phone number in the address no longer makes the payment fail. Numbers in national format are now normalized to E.164 (including numbers entered for Bancomat Pay / Bizum); numbers that cannot be normalized are removed from the payload.
 - Fixed: Payments no longer fail when the shipping method name is empty. "Shipping" is used as a fallback.
 - Fixed: Plugin updates no longer fail with a 500 error on Shopware 6.5.
 - Fixed: The storefront no longer breaks with a "Plugin is already registered" error on Shopware 6.5.

--- a/shopware/Component/Mollie/PhoneNumber.php
+++ b/shopware/Component/Mollie/PhoneNumber.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\Shopware\Component\Mollie;
+
+final class PhoneNumber
+{
+    /**
+     * E.164 phone numbers start with a "+", a non-zero country code and hold at most 15 digits.
+     */
+    public const E164_PATTERN = '/^\+[1-9]\d{1,14}$/';
+
+    /**
+     * Country calling codes for countries whose national number format uses a "0" trunk
+     * prefix that is dropped in the international format. Only for these countries a number
+     * in national format (leading "0") can be converted safely. Countries without a trunk
+     * prefix (e.g. ES, DK, NO) or with a non-standard one (e.g. IT keeps the leading zero,
+     * HU uses "06") are intentionally not listed.
+     */
+    private const COUNTRY_CALLING_CODES = [
+        'AT' => '+43',
+        'BE' => '+32',
+        'CH' => '+41',
+        'DE' => '+49',
+        'FI' => '+358',
+        'FR' => '+33',
+        'GB' => '+44',
+        'IE' => '+353',
+        'LU' => '+352',
+        'NL' => '+31',
+        'SE' => '+46',
+    ];
+
+    public static function isValidE164(string $phone): bool
+    {
+        return preg_match(self::E164_PATTERN, $phone) === 1;
+    }
+
+    /**
+     * Tries to convert a customer-entered phone number to E.164: separators and a "(0)" infix
+     * are stripped, an international "00" prefix becomes "+" and a number in national format
+     * (leading "0") gets the calling code of the given address country. Returns an empty
+     * string when the number cannot be converted to a valid E.164 representation.
+     */
+    public static function toE164(string $phone, string $countryIso): string
+    {
+        $phone = str_replace('(0)', '', trim($phone));
+        $phone = (string) preg_replace('/[\s\/\-\(\)\.]+/', '', $phone);
+
+        if ($phone === '') {
+            return '';
+        }
+
+        if (strncmp($phone, '00', 2) === 0) {
+            $phone = '+' . substr($phone, 2);
+        } elseif (strncmp($phone, '0', 1) === 0) {
+            $callingCode = self::COUNTRY_CALLING_CODES[strtoupper($countryIso)] ?? null;
+            if ($callingCode === null) {
+                return '';
+            }
+            $phone = $callingCode . substr($phone, 1);
+        }
+
+        return self::isValidE164($phone) ? $phone : '';
+    }
+}

--- a/shopware/Component/Payment/PayloadBuilder.php
+++ b/shopware/Component/Payment/PayloadBuilder.php
@@ -18,6 +18,7 @@ use Mollie\Shopware\Component\Mollie\Locale;
 use Mollie\Shopware\Component\Mollie\Mandate;
 use Mollie\Shopware\Component\Mollie\Mode;
 use Mollie\Shopware\Component\Mollie\Money;
+use Mollie\Shopware\Component\Mollie\PhoneNumber;
 use Mollie\Shopware\Component\Mollie\RoundingDifferenceFixer;
 use Mollie\Shopware\Component\Mollie\RoundingDifferenceFixerInterface;
 use Mollie\Shopware\Component\Mollie\SequenceType;
@@ -46,11 +47,6 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class PayloadBuilder implements PayloadBuilderInterface
 {
-    /**
-     * E.164 phone numbers start with a "+", a non-zero country code and hold at most 15 digits.
-     */
-    private const E164_PATTERN = '/^\+[1-9]\d{1,14}$/';
-
     /**
      * @param EntityRepository<CustomerCollection<CustomerEntity>> $customerRepository
      */
@@ -160,9 +156,6 @@ final class PayloadBuilder implements PayloadBuilderInterface
 
         $billingAddress = Address::fromAddress($customer, $billingOrderAddress);
 
-        $this->removeInvalidPhoneNumber($shippingAddress, $logData);
-        $this->removeInvalidPhoneNumber($billingAddress, $logData);
-
         $orderAmount = Money::fromOrder($order, $currency);
 
         if ($paymentSettings->isFixRoundingDiffEnabled()) {
@@ -225,6 +218,10 @@ final class PayloadBuilder implements PayloadBuilderInterface
         /** @var CreatePayment $createPaymentStruct */
         $createPaymentStruct = $paymentHandler->applyPaymentSpecificParameters($createPaymentStruct, $dataBag, $customer);
 
+        // after the handler parameters, so numbers set there (e.g. Bancomat Pay/Bizum) are covered too
+        $this->normalizePhoneNumber($createPaymentStruct->getShippingAddress(), $logData);
+        $this->normalizePhoneNumber($createPaymentStruct->getBillingAddress(), $logData);
+
         $logData['payload'] = $createPaymentStruct->toArray();
         $this->logger->info('Payment payload created for mollie API', $logData);
 
@@ -255,6 +252,13 @@ final class PayloadBuilder implements PayloadBuilderInterface
 
         /** @var CreateOrder $createOrder */
         $createOrder = $paymentHandler->applyPaymentSpecificParameters($createOrder, $dataBag, $transactionData->getCustomer());
+
+        $orderLogData = ['orderNumber' => $createPayment->getShopwareOrderNumber()];
+        $orderShippingAddress = $createOrder->getShippingAddress();
+        if ($orderShippingAddress !== null) {
+            $this->normalizePhoneNumber($orderShippingAddress, $orderLogData);
+        }
+        $this->normalizePhoneNumber($createOrder->getBillingAddress(), $orderLogData);
 
         $this->logger->info('Order payload created for mollie API', [
             'orderNumber' => $createPayment->getShopwareOrderNumber(),
@@ -294,25 +298,32 @@ final class PayloadBuilder implements PayloadBuilderInterface
 
     /**
      * Mollie rejects phone numbers that are not in E.164 format and fails the whole payment.
-     * To keep the checkout working we drop an invalid number from the payload and only log a
-     * masked hint (never the full number) for troubleshooting.
+     * To keep the checkout working we first try to normalize the number to E.164 (most
+     * customers enter their number in national format) and drop it from the payload if it
+     * cannot be normalized. Only a masked hint (never the full number) is logged.
      *
      * @param array<string, mixed> $logData
      */
-    private function removeInvalidPhoneNumber(Address $address, array $logData): void
+    private function normalizePhoneNumber(Address $address, array $logData): void
     {
         $phone = $address->getPhone();
-        if ($phone === '') {
+        if ($phone === '' || PhoneNumber::isValidE164($phone)) {
             return;
         }
 
-        if (preg_match(self::E164_PATTERN, $phone) === 1) {
+        $logData['phoneHint'] = mb_substr($phone, 0, 2) . '***';
+
+        $normalized = PhoneNumber::toE164($phone, $address->getCountry());
+        if ($normalized !== '') {
+            $address->setPhone($normalized);
+
+            $this->logger->info('Phone number was normalized to E.164 format for the mollie payload', $logData);
+
             return;
         }
 
         $address->setPhone('');
 
-        $logData['phoneHint'] = mb_substr($phone, 0, 2) . '***';
         $this->logger->warning('Phone number is not in E.164 format and was removed from the mollie payload to prevent a payment failure', $logData);
     }
 

--- a/tests/Unit/Mollie/PhoneNumberTest.php
+++ b/tests/Unit/Mollie/PhoneNumberTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\Shopware\Unit\Mollie;
+
+use Mollie\Shopware\Component\Mollie\PhoneNumber;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PhoneNumber::class)]
+final class PhoneNumberTest extends TestCase
+{
+    #[DataProvider('phoneNumberProvider')]
+    public function testToE164(string $phone, string $countryIso, string $expected): void
+    {
+        $this->assertSame($expected, PhoneNumber::toE164($phone, $countryIso));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function phoneNumberProvider(): array
+    {
+        return [
+            'already E.164' => ['+491711234567', 'DE', '+491711234567'],
+            'E.164 with separators' => ['+49 171 123-45.67', 'DE', '+491711234567'],
+            'E.164 with (0) infix' => ['+49 (0)171 1234567', 'DE', '+491711234567'],
+            'international 00 prefix' => ['0049 171 1234567', 'DE', '+491711234567'],
+            'national german mobile' => ['0171/1234567', 'DE', '+491711234567'],
+            'national german landline' => ['030 123 45 67', 'DE', '+49301234567'],
+            'national austrian mobile' => ['0664 123456', 'AT', '+43664123456'],
+            'national dutch mobile' => ['06-12345678', 'NL', '+31612345678'],
+            'national with lowercase iso' => ['0171 1234567', 'de', '+491711234567'],
+            'national with unknown country' => ['0699 12345678', 'US', ''],
+            'national with country without trunk prefix' => ['0612345678', 'ES', ''],
+            'letters' => ['no phone', 'DE', ''],
+            'letters after plus' => ['+49abc171', 'DE', ''],
+            'too long' => ['+4917112345678901234', 'DE', ''],
+            'only separators' => [' - / ', 'DE', ''],
+            'empty' => ['', 'DE', ''],
+        ];
+    }
+
+    public function testValidE164IsAccepted(): void
+    {
+        $this->assertTrue(PhoneNumber::isValidE164('+491711234567'));
+    }
+
+    public function testNationalFormatIsNotValidE164(): void
+    {
+        $this->assertFalse(PhoneNumber::isValidE164('0171 1234567'));
+    }
+}

--- a/tests/Unit/Payment/Fake/FakePhoneAwarePaymentMethodHandler.php
+++ b/tests/Unit/Payment/Fake/FakePhoneAwarePaymentMethodHandler.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Mollie\Shopware\Unit\Payment\Fake;
+
+use Mollie\Shopware\Component\Mollie\PaymentMethod;
+use Mollie\Shopware\Component\Mollie\PaymentParameterInterface;
+use Mollie\Shopware\Component\Payment\Handler\AbstractMolliePaymentHandler;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+
+/**
+ * Mimics handlers like Bancomat Pay / Bizum that overwrite the billing phone number
+ * from a storefront input inside applyPaymentSpecificParameters().
+ */
+final class FakePhoneAwarePaymentMethodHandler extends AbstractMolliePaymentHandler
+{
+    public function __construct()
+    {
+    }
+
+    public function getPaymentMethod(): PaymentMethod
+    {
+        return PaymentMethod::BANCOMAT_PAY;
+    }
+
+    public function getName(): string
+    {
+        return 'Fake phone aware payment method';
+    }
+
+    public function applyPaymentSpecificParameters(PaymentParameterInterface $payment, RequestDataBag $dataBag, CustomerEntity $customer): PaymentParameterInterface
+    {
+        $billingAddress = $payment->getBillingAddress();
+        $billingAddress->setPhone((string) $dataBag->get('molliePayPhone', $billingAddress->getPhone()));
+
+        return $payment;
+    }
+}

--- a/tests/Unit/Payment/PayloadBuilderTest.php
+++ b/tests/Unit/Payment/PayloadBuilderTest.php
@@ -25,6 +25,7 @@ use Mollie\Shopware\Unit\Payment\Fake\FakeGateway;
 use Mollie\Shopware\Unit\Payment\Fake\FakeManualCaptureModeAwarePaymentHandler;
 use Mollie\Shopware\Unit\Payment\Fake\FakeOrdersApiAwarePaymentHandler;
 use Mollie\Shopware\Unit\Payment\Fake\FakePaymentMethodHandler;
+use Mollie\Shopware\Unit\Payment\Fake\FakePhoneAwarePaymentMethodHandler;
 use Mollie\Shopware\Unit\Payment\Fake\FakeRecurringAwarePaymentHandler;
 use Mollie\Shopware\Unit\Payment\Fake\FakeSubscriptionAwarePaymentHandler;
 use Mollie\Shopware\Unit\Transaction\Fake\FakeTransactionService;
@@ -543,7 +544,7 @@ final class PayloadBuilderTest extends TestCase
         $this->assertSame('+4930123456789', $array['shippingAddress']['phone']);
     }
 
-    public function testBuildRemovesInvalidPhoneNumberAndLogsWarning(): void
+    public function testBuildNormalizesNationalPhoneNumber(): void
     {
         $logger = new FakeLogger();
         $builder = $this->createBuilder(logger: $logger);
@@ -555,13 +556,48 @@ final class PayloadBuilderTest extends TestCase
         $actual = $builder->buildPayment($transactionData, new FakePaymentMethodHandler(), new RequestDataBag(), $this->context);
 
         $array = $actual->toArray();
+        $this->assertSame('+4930123456', $array['billingAddress']['phone']);
+        $this->assertSame('+4930123456', $array['shippingAddress']['phone']);
+
+        $this->assertTrue($logger->hasRecordThatContains(LogLevel::INFO, 'normalized to E.164'));
+        foreach ($logger->getRecords() as $record) {
+            $this->assertStringNotContainsString('030 / 123 456', json_encode($record) ?: '');
+        }
+    }
+
+    public function testBuildRemovesUnfixablePhoneNumberAndLogsWarning(): void
+    {
+        $logger = new FakeLogger();
+        $builder = $this->createBuilder(logger: $logger);
+
+        $transactionService = new FakeTransactionService();
+        $transactionService->withPhoneNumber('call me maybe');
+        $transactionData = $transactionService->findById('test', $this->context);
+
+        $actual = $builder->buildPayment($transactionData, new FakePaymentMethodHandler(), new RequestDataBag(), $this->context);
+
+        $array = $actual->toArray();
         $this->assertArrayNotHasKey('phone', $array['billingAddress']);
         $this->assertArrayNotHasKey('phone', $array['shippingAddress']);
 
         $this->assertTrue($logger->hasRecordThatContains(LogLevel::WARNING, 'E.164'));
         foreach ($logger->getRecords() as $record) {
-            $this->assertStringNotContainsString('030 / 123 456', json_encode($record) ?: '');
+            $this->assertStringNotContainsString('call me maybe', json_encode($record) ?: '');
         }
+    }
+
+    public function testBuildNormalizesPhoneNumberSetByPaymentHandler(): void
+    {
+        $builder = $this->createBuilder();
+
+        $transactionData = (new FakeTransactionService())->findById('test', $this->context);
+
+        $dataBag = new RequestDataBag(['molliePayPhone' => '0171 / 2345678']);
+
+        $actual = $builder->buildPayment($transactionData, new FakePhoneAwarePaymentMethodHandler(), $dataBag, $this->context);
+
+        $array = $actual->toArray();
+        $this->assertSame('+491712345678', $array['billingAddress']['phone']);
     }
 
     public function testBuildOrderReturnsCreateOrderInstance(): void


### PR DESCRIPTION
Follow-up to #1340 / 4095dadf, as offered in the issue.

### What this PR does

**1. Closes the gap for handler-set phone numbers.**
The check from 4095dadf runs in `buildPayment()` *before* `applyPaymentSpecificParameters()`, so numbers written there — Bancomat Pay / Bizum overwrite the billing phone from the storefront `molliePayPhone` field — still reached the Mollie API unvalidated and failed the whole payment. The normalization now runs *after* the handler parameters, in both `buildPayment()` and `buildOrder()`.

**2. Normalizes before dropping.**
Most "invalid" numbers are trivially fixable, and the address country is already available on the `Address` struct. The new `Mollie\Shopware\Component\Mollie\PhoneNumber::toE164()`:

- strips separators and a `(0)` infix: `+49 (0)171-2345678` → `+491712345678` (Apple Pay hands over numbers with spaces, so these no longer get dropped)
- converts an international `00` prefix: `0049171...` → `+49171...`
- converts national format using the calling code of the address country: `0171/2345678` + `DE` → `+491712345678`

Only if the number still isn't valid E.164 after that, it is removed from the payload — with the existing masked warning log. Successful normalization is logged at info level.

The calling-code map deliberately only contains countries whose national format uses a `0` trunk prefix that is dropped internationally (DE, AT, CH, NL, BE, FR, LU, GB, IE, SE, FI). Countries without a trunk prefix (ES, DK, NO, ...) or with non-standard rules (IT keeps the leading zero, HU uses `06`) are not mapped, so those numbers are dropped rather than mangled.

We have been running this normalization in production (German shop, ~all customers with national-format numbers) since Monday — it recovers virtually every real-world number instead of losing it.

### Tests

- New `PhoneNumberTest` covering normalization and edge cases
- `PayloadBuilderTest`: the previous removal test now asserts normalization (`030 / 123 456` → `+4930123456`), a new test covers a non-normalizable number (removal + masked warning), and a new fake handler mimicking Bancomat Pay proves numbers set via `applyPaymentSpecificParameters()` are normalized too
- Full unit suite green, `php-cs-fixer` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)