### PR TITLE
fix: fall back gracefully for storefront locales not supported by Mollie (fixes #1344)

### DIFF
--- a/shopware/Component/Mollie/Locale.php
+++ b/shopware/Component/Mollie/Locale.php
@@ -46,6 +46,32 @@ enum Locale: string
     {
         $languageLocale = str_replace('-', '_', $code);
 
-        return self::from($languageLocale);
+        $locale = self::tryFrom($languageLocale);
+        if ($locale !== null) {
+            return $locale;
+        }
+
+        // locale is not supported by Mollie, fall back to one with the same language (e.g. de_LU -> de_DE)
+        $parts = explode('_', $languageLocale);
+        $language = strtolower($parts[0]);
+        if ($language !== '') {
+            foreach (self::cases() as $case) {
+                if (str_starts_with($case->value, $language . '_')) {
+                    return $case;
+                }
+            }
+        }
+
+        // unknown language, fall back to one used in the same region (e.g. gsw_CH -> de_CH)
+        $region = strtoupper($parts[1] ?? '');
+        if ($region !== '') {
+            foreach (self::cases() as $case) {
+                if (str_ends_with($case->value, '_' . $region)) {
+                    return $case;
+                }
+            }
+        }
+
+        return self::enGB;
     }
 }

--- a/tests/Unit/Mollie/LocaleTest.php
+++ b/tests/Unit/Mollie/LocaleTest.php
@@ -71,4 +71,27 @@ final class LocaleTest extends TestCase
             $this->assertSame($expectedLocale, $actual);
         }
     }
+
+    public function testUnsupportedLocaleFallsBackInsteadOfThrowing(): void
+    {
+        $testCases = [
+            'cs-CZ' => Locale::enGB, // unknown language and region
+            'sk-SK' => Locale::enGB, // unknown language and region
+            'de-LU' => Locale::deDE, // same language available
+            'en-AU' => Locale::enGB, // same language available
+            'gsw-CH' => Locale::deCH, // unknown language, same region available
+        ];
+
+        foreach ($testCases as $code => $expectedLocale) {
+            $locale = new LocaleEntity();
+            $locale->setCode($code);
+
+            $language = new LanguageEntity();
+            $language->setLocale($locale);
+
+            $actual = Locale::fromLanguage($language);
+
+            $this->assertSame($expectedLocale, $actual, sprintf('Locale "%s" should fall back to "%s"', $code, $expectedLocale->value));
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1344

## Problem
`Locale::fromLocaleCode()` uses `self::from()`, which throws a `ValueError` for any storefront locale that is not part of the enum (e.g. `cs_CZ`, `sk_SK`, `gsw_CH`).

In `StoreFrontDataSubscriber::addDataToPage()` the exception aborts the whole `try` block, so on affected sales channels the checkout confirm and account order edit pages never receive `mollie_locale`, `mollie_profile_id`, the credit card component settings or POS terminals — and the error is logged on every page view.

## Fix
`fromLocaleCode()` now falls back gracefully instead of throwing:

1. exact match (unchanged)
2. a supported locale with the same language, e.g. `de_LU` → `de_DE`
3. a supported locale of the same region, e.g. `gsw_CH` → `de_CH`
4. `en_GB`

This restores the v4.x behaviour (`MollieLocaleService` fell back to `en_GB`), while picking a better-matching locale where possible.

## Tests
Added `testUnsupportedLocaleFallsBackInsteadOfThrowing` to `tests/Unit/Mollie/LocaleTest.php` covering all three fallback stages.

```
OK (4 tests, 27 assertions)
```

php-cs-fixer (config/.php_cs.php) and phpstan pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
