### PR TITLE
fix: map line items with negative price to discount type (fixes #1347)

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -10,6 +10,7 @@
 - Behoben: Die Storefront bricht auf Shopware 6.5 nicht mehr mit dem Fehler „Plugin is already registered" ab.
 - Behoben: Die Anzeige-Einschränkungen für Apple Pay Direct greifen nun, sodass der Button auf den konfigurierten Seiten ausgeblendet wird.
 - Behoben: Storefront-Seiten brechen bei von Mollie nicht unterstützten Locales (z. B. cs_CZ, sk_SK) nicht mehr ab. Die Locale weicht nun auf eine unterstützte oder auf en_GB aus.
+- Behoben: Zahlungen schlagen nicht mehr fehl, wenn der Warenkorb einen Rabatt eines Drittanbieter-Plugins enthält (eigener Positionstyp mit negativem Preis). Solche Positionen werden nun als Typ 'discount' an Mollie übertragen.
 
 # 5.0.0
 - Hinweis: Durch Autoloader-Caching kann beim Hochladen/Update des Plugins ein Fehler erscheinen. Dieser kann ignoriert werden.

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -10,6 +10,7 @@
 - Fixed: The storefront no longer breaks with a "Plugin is already registered" error on Shopware 6.5.
 - Fixed: Apple Pay Direct display restrictions are now applied, so the button is hidden on the configured pages.
 - Fixed: Storefront pages no longer break on locales that Mollie does not support (e.g. cs_CZ, sk_SK). The locale now falls back to a supported one, or to en_GB.
+- Fixed: Payments no longer fail when the cart contains a discount from a third-party plugin (custom line item type with a negative price). Such line items are now sent to Mollie as type 'discount'.
 
 # 5.0.0
 - Note: Due to autoloader caching, an error can appear when uploading/updating the plugin. It can be ignored.

--- a/shopware/Component/Mollie/LineItemType.php
+++ b/shopware/Component/Mollie/LineItemType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Mollie\Shopware\Component\Mollie;
 
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 
 enum LineItemType: string
@@ -22,11 +23,24 @@ enum LineItemType: string
     {
         $oderLineItemType = (string) $orderLineItem->getType();
 
-        return match ($oderLineItemType) {
+        $type = match ($oderLineItemType) {
             LineItem::PRODUCT_LINE_ITEM_TYPE, self::LINE_ITEM_TYPE_CUSTOM_PRODUCTS->value => self::PHYSICAL,
             LineItem::CREDIT_LINE_ITEM_TYPE => self::CREDIT,
             LineItem::PROMOTION_LINE_ITEM_TYPE => self::DISCOUNT,
             default => self::DIGITAL,
         };
+
+        if ($type === self::CREDIT || $type === self::GIFT_CARD) {
+            return $type;
+        }
+
+        // discounts added by third-party plugins have custom line item types, Mollie rejects
+        // negative amounts unless the type is discount, store_credit or gift_card
+        $price = $orderLineItem->getPrice();
+        if ($price instanceof CalculatedPrice && $price->getTotalPrice() < 0) {
+            return self::DISCOUNT;
+        }
+
+        return $type;
     }
 }

--- a/tests/Unit/Mollie/LineItemTypeTest.php
+++ b/tests/Unit/Mollie/LineItemTypeTest.php
@@ -7,6 +7,9 @@ use Mollie\Shopware\Component\Mollie\LineItemType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 
 #[CoversClass(LineItemType::class)]
@@ -78,6 +81,36 @@ final class LineItemTypeTest extends TestCase
     {
         $orderLineItem = new OrderLineItemEntity();
         $orderLineItem->setType('shipping');
+
+        $result = LineItemType::fromOderLineItem($orderLineItem);
+
+        $this->assertSame(LineItemType::DIGITAL, $result);
+    }
+
+    public function testFromOrderLineItemWithNegativePriceBecomesDiscount(): void
+    {
+        $testCases = [
+            'custom-discount' => LineItemType::DISCOUNT,
+            LineItem::PRODUCT_LINE_ITEM_TYPE => LineItemType::DISCOUNT,
+            LineItem::CREDIT_LINE_ITEM_TYPE => LineItemType::CREDIT,
+        ];
+
+        foreach ($testCases as $shopwareType => $expectedType) {
+            $orderLineItem = new OrderLineItemEntity();
+            $orderLineItem->setType($shopwareType);
+            $orderLineItem->setPrice(new CalculatedPrice(-10.0, -10.0, new CalculatedTaxCollection(), new TaxRuleCollection()));
+
+            $result = LineItemType::fromOderLineItem($orderLineItem);
+
+            $this->assertSame($expectedType, $result, sprintf('Negative line item of type "%s" should map to "%s"', $shopwareType, $expectedType->value));
+        }
+    }
+
+    public function testFromOrderLineItemWithPositivePriceKeepsType(): void
+    {
+        $orderLineItem = new OrderLineItemEntity();
+        $orderLineItem->setType('custom-surcharge');
+        $orderLineItem->setPrice(new CalculatedPrice(10.0, 10.0, new CalculatedTaxCollection(), new TaxRuleCollection()));
 
         $result = LineItemType::fromOderLineItem($orderLineItem);
 


### PR DESCRIPTION
Fixes #1347

## Problem
`LineItemType::fromOderLineItem()` maps every line item type it does not know to `digital`. Discounts added by third-party plugins (vouchers, customer discounts, …) use custom line item types, so they are sent to the Mollie API as `digital` with a negative `unitPrice` — the API rejects the whole payment:

```
Error in field lines.10.unitPrice. Unprocessable Entity: Line item 10 is invalid.
The 'unitPrice' field cannot be negative, unless the 'type' is one of the following:
'discount', 'store_credit', and 'gift_card'
```

This is a regression from v4, where `MollieLineItemBuilder` explicitly mapped any line item with a negative total price to `TYPE_DISCOUNT`:

```php
if ($item->getType() === $this->getLineItemPromotionType() || $item->getTotalPrice() < 0) {
    return OrderLineType::TYPE_DISCOUNT;
}
```

## Fix
`fromOderLineItem()` now returns `DISCOUNT` for any line item with a negative total price, unless the type already resolved to `store_credit` or `gift_card` (which Mollie also accepts with negative amounts). The price is read via `getPrice()` (nullable, safe on partially hydrated entities) instead of the non-nullable `totalPrice` property.

Shipping lines are unaffected — negative shipping costs are already handled in `LineItem::fromShippingCosts()`, and the `RoundingDifferenceFixer` already sets `DISCOUNT` for negative rounding lines.

## Tests
Added two tests to `tests/Unit/Mollie/LineItemTypeTest.php`:
- negative custom-type, negative product and negative credit line items map to `discount` / `store_credit`
- positive custom-type line items still map to `digital`

```
OK (9 tests, 18 assertions)   # LineItemTypeTest
OK, but there were issues!    # full tests/Unit: 818 tests, 2116 assertions (pre-existing PHPUnit notices only)
```

php-cs-fixer (config/.php_cs.php) and phpstan pass on the changed files.

Verified against a real failed order (net tax status, cart promotion + third-party voucher line): the voucher line now resolves to `discount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
