### PR TITLE
fix: use translated shipping method name for the Mollie shipping line

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -11,6 +11,7 @@
 - Behoben: Die Anzeige-Einschränkungen für Apple Pay Direct greifen nun, sodass der Button auf den konfigurierten Seiten ausgeblendet wird.
 - Behoben: Storefront-Seiten brechen bei von Mollie nicht unterstützten Locales (z. B. cs_CZ, sk_SK) nicht mehr ab. Die Locale weicht nun auf eine unterstützte oder auf en_GB aus.
 - Behoben: Zahlungen schlagen nicht mehr fehl, wenn der Warenkorb einen Rabatt eines Drittanbieter-Plugins enthält (eigener Positionstyp mit negativem Preis). Solche Positionen werden nun als Typ 'discount' an Mollie übertragen.
+- Behoben: Die an Mollie übertragene Versandzeile verwendet nun den übersetzten Namen der Versandart. Storefront-Sprachen ohne eigene Versandart-Übersetzung schlagen nicht mehr fehl (vor dem „Shipping“-Fallback) bzw. zeigen nicht mehr das generische „Shipping“; der Name fällt nun über die Sprachkette zurück.
 
 # 5.0.0
 - Hinweis: Durch Autoloader-Caching kann beim Hochladen/Update des Plugins ein Fehler erscheinen. Dieser kann ignoriert werden.

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -11,6 +11,7 @@
 - Fixed: Apple Pay Direct display restrictions are now applied, so the button is hidden on the configured pages.
 - Fixed: Storefront pages no longer break on locales that Mollie does not support (e.g. cs_CZ, sk_SK). The locale now falls back to a supported one, or to en_GB.
 - Fixed: Payments no longer fail when the cart contains a discount from a third-party plugin (custom line item type with a negative price). Such line items are now sent to Mollie as type 'discount'.
+- Fixed: The shipping line sent to Mollie now uses the translated shipping method name. Storefront languages without an own shipping method translation no longer fail (before the 'Shipping' fallback) or show the generic 'Shipping' label; the name now falls back through the language chain.
 
 # 5.0.0
 - Note: Due to autoloader caching, an error can appear when uploading/updating the plugin. It can be ignored.

--- a/shopware/Component/Mollie/LineItem.php
+++ b/shopware/Component/Mollie/LineItem.php
@@ -66,7 +66,11 @@ final class LineItem implements \JsonSerializable
         }
         $shippingCosts = $delivery->getShippingCosts();
 
-        $description = $descriptionOverride ?? (string) $shippingMethod->getName();
+        // getName() only contains the translation of the first language in the context chain and is
+        // null e.g. for storefront languages without an own translation; getTranslation() falls back
+        // through the language chain
+        $shippingMethodName = $shippingMethod->getTranslation('name') ?? $shippingMethod->getName();
+        $description = $descriptionOverride ?? (string) $shippingMethodName;
         $description = trim($description);
         if (mb_strlen($description) === 0) {
             $description = 'Shipping';

--- a/tests/Unit/Fake/OrderEntityBuilder.php
+++ b/tests/Unit/Fake/OrderEntityBuilder.php
@@ -169,6 +169,21 @@ final class OrderEntityBuilder
         return $delivery;
     }
 
+    public function getOrderDeliveryWithTranslatedShippingMethodName(CustomerEntity $customer): OrderDeliveryEntity
+    {
+        $shippingMethod = new ShippingMethodEntity();
+        $shippingMethod->setId('fake-shipping-method-id');
+        $shippingMethod->setTranslated(['name' => 'DHL Translated']);
+
+        $delivery = new OrderDeliveryEntity();
+        $delivery->setId('fake-delivery-translated-name');
+        $delivery->setShippingOrderAddress($this->getOrderAddress($customer));
+        $delivery->setShippingCosts($this->getPrice(4.99, 19.0));
+        $delivery->setShippingMethod($shippingMethod);
+
+        return $delivery;
+    }
+
     public function getOrderLineItemWithoutPrice(): OrderLineItemEntity
     {
         $orderLineItem = new OrderLineItemEntity();

--- a/tests/Unit/Mollie/LineItemTest.php
+++ b/tests/Unit/Mollie/LineItemTest.php
@@ -91,6 +91,19 @@ final class LineItemTest extends TestCase
         $this->assertEquals($expected['amount'], $actual->getAmount());
     }
 
+    public function testCreateFromDeliveryUsesTranslatedShippingMethodName(): void
+    {
+        $customerRepository = new CustomerEntityBuilder();
+        $customer = $customerRepository->getDefaultCustomer();
+        $delivery = $this->orderRepository->getOrderDeliveryWithTranslatedShippingMethodName($customer);
+        $currency = new CurrencyEntity();
+        $currency->setIsoCode('EUR');
+
+        $actual = LineItem::fromDelivery($delivery, $currency);
+
+        $this->assertSame('DHL Translated', $actual->getDescription());
+    }
+
     public function testCreateFromDeliveryFallsBackToShippingWhenNameIsEmpty(): void
     {
         $customerRepository = new CustomerEntityBuilder();


### PR DESCRIPTION
## Problem
`LineItem::fromDelivery()` reads the shipping method name via `getName()`. In the DAL, `getName()` only contains the translation of the **first** language in the context language chain — for storefront languages without an own shipping method translation it is `null`, even though the language chain could resolve the name (e.g. `gsw-CH` → system default).

On 5.0.0 this made the whole payment fail, because the shipping line was serialized without a `description`:

```
There was an error from Mollies API
{"title":"Unprocessable Entity","error":"Line item 3 is invalid. The 'description' field is missing","field":"lines.3.description"}
```

The recently added `'Shipping'` fallback (unreleased) fixes the failure itself, but customers on those storefront languages still see a generic "Shipping" line on the Mollie checkout page instead of their shipping method name — even though a perfectly good translation exists further down the language chain.

Reproduced on a live Shopware 6.6.10.1 shop: order in `gsw-CH` (Swiss German, parent = system default), shipping method translated only in the system default language:

```
chain [gsw-CH, system]: getName(): NULL | getTranslation('name'): 'DHL CH'
```

## Fix
Resolve the name via `getTranslation('name')` (falls back through the language chain) and only then fall back to `getName()` and finally `'Shipping'`:

```php
$shippingMethodName = $shippingMethod->getTranslation('name') ?? $shippingMethod->getName();
```

## Tests
Added `testCreateFromDeliveryUsesTranslatedShippingMethodName` (shipping method with only `translated['name']` set). The existing empty-name fallback test still passes.

```
OK (11 tests, 46 assertions)      # LineItemTest
Tests: 820, Assertions: 2122      # full tests/Unit (pre-existing PHPUnit notices only)
```

php-cs-fixer (config/.php_cs.php) and phpstan pass on the changed files. Changelog entries (en-GB, de-DE) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
