### PR TITLE
fix: derive line vatAmount when the rounded Shopware tax breaks Mollie's validation

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -12,6 +12,7 @@
 - Behoben: Storefront-Seiten brechen bei von Mollie nicht unterstützten Locales (z. B. cs_CZ, sk_SK) nicht mehr ab. Die Locale weicht nun auf eine unterstützte oder auf en_GB aus.
 - Behoben: Zahlungen schlagen nicht mehr fehl, wenn der Warenkorb einen Rabatt eines Drittanbieter-Plugins enthält (eigener Positionstyp mit negativem Preis). Solche Positionen werden nun als Typ 'discount' an Mollie übertragen.
 - Behoben: Die an Mollie übertragene Versandzeile verwendet nun den übersetzten Namen der Versandart. Storefront-Sprachen ohne eigene Versandart-Übersetzung schlagen nicht mehr fehl (vor dem „Shipping“-Fallback) bzw. zeigen nicht mehr das generische „Shipping“; der Name fällt nun über die Sprachkette zurück.
+- Behoben: Zahlungen schlagen nicht mehr mit „The 'vatAmount' field is off“ fehl, wenn Shopware die Währung auf ganze Beträge rundet (0 Nachkommastellen bei der Positionsrundung, z. B. PLN, SEK, CZK). Verletzt die gerundete Shopware-Steuer Mollies vatAmount-Validierung, wird das vatAmount nun aus dem übertragenen totalAmount abgeleitet.
 
 # 5.0.0
 - Hinweis: Durch Autoloader-Caching kann beim Hochladen/Update des Plugins ein Fehler erscheinen. Dieser kann ignoriert werden.

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -12,6 +12,7 @@
 - Fixed: Storefront pages no longer break on locales that Mollie does not support (e.g. cs_CZ, sk_SK). The locale now falls back to a supported one, or to en_GB.
 - Fixed: Payments no longer fail when the cart contains a discount from a third-party plugin (custom line item type with a negative price). Such line items are now sent to Mollie as type 'discount'.
 - Fixed: The shipping line sent to Mollie now uses the translated shipping method name. Storefront languages without an own shipping method translation no longer fail (before the 'Shipping' fallback) or show the generic 'Shipping' label; the name now falls back through the language chain.
+- Fixed: Payments no longer fail with "The 'vatAmount' field is off" in currencies that Shopware rounds to whole amounts (zero item-rounding decimals, e.g. PLN, SEK, CZK). When the rounded Shopware tax breaks Mollie's vatAmount validation, the vatAmount is now derived from the transmitted totalAmount.
 
 # 5.0.0
 - Note: Due to autoloader caching, an error can appear when uploading/updating the plugin. It can be ignored.

--- a/shopware/Component/Mollie/LineItem.php
+++ b/shopware/Component/Mollie/LineItem.php
@@ -492,8 +492,22 @@ final class LineItem implements \JsonSerializable
         $lineItem = new self($label, $price->getQuantity(), $unitPrice, $totalPrice);
 
         if ($tax instanceof CalculatedTax) {
-            $lineItem->setVatAmount(new Money($tax->getTax(), $currency->getIsoCode()));
-            $lineItem->setVatRate((string) $tax->getTaxRate());
+            $vatRate = $tax->getTaxRate();
+            $vatAmount = new Money($tax->getTax(), $currency->getIsoCode());
+
+            // Shopware rounds line taxes to the currency's item-rounding decimals (often 0 for
+            // PLN, SEK or CZK), but Mollie validates vatAmount === totalAmount × vatRate / (100 + vatRate)
+            // on the transmitted values and rejects the payment otherwise ("The 'vatAmount' field is off").
+            // If the Shopware tax breaks that invariant, derive the vatAmount from the transmitted totalAmount.
+            $decimals = $totalPrice->getDecimals();
+            $transmittedTotal = round($totalPrice->getValue(), $decimals);
+            $expectedVatAmount = round($transmittedTotal * $vatRate / (100 + $vatRate), $decimals);
+            if (round($vatAmount->getValue(), $decimals) !== $expectedVatAmount) {
+                $vatAmount = new Money($expectedVatAmount, $currency->getIsoCode());
+            }
+
+            $lineItem->setVatAmount($vatAmount);
+            $lineItem->setVatRate((string) $vatRate);
         }
 
         return $lineItem;

--- a/tests/Unit/Fake/OrderEntityBuilder.php
+++ b/tests/Unit/Fake/OrderEntityBuilder.php
@@ -321,6 +321,26 @@ final class OrderEntityBuilder
         return $orderLineItem;
     }
 
+    public function getLineItemWithWholeNumberRoundedTax(): OrderLineItemEntity
+    {
+        // currencies with zero item-rounding decimals (e.g. PLN) store whole-number taxes:
+        // 678.00 at 23% is stored as 127.00 instead of 126.78
+        $taxes = new CalculatedTaxCollection([
+            new CalculatedTax(127.0, 23.0, 678.0),
+        ]);
+
+        $price = new CalculatedPrice(678.0, 678.0, $taxes, new TaxRuleCollection(), 1);
+
+        $orderLineItem = new OrderLineItemEntity();
+        $orderLineItem->setId('fake-whole-number-tax-line-item-id');
+        $orderLineItem->setType('product');
+        $orderLineItem->setLabel('Whole number tax product');
+        $orderLineItem->setQuantity(1);
+        $orderLineItem->setPrice($price);
+
+        return $orderLineItem;
+    }
+
     private function createOrderLineItem(string $id, string $productNumber, string $label, float $price, $voucherCategories = null): OrderLineItemEntity
     {
         $product = new ProductEntity();

--- a/tests/Unit/Mollie/LineItemTest.php
+++ b/tests/Unit/Mollie/LineItemTest.php
@@ -217,6 +217,35 @@ final class LineItemTest extends TestCase
         $this->assertSame($expectedVatAmount, $vatAmount);
     }
 
+    /**
+     * Currencies configured with zero item-rounding decimals (e.g. PLN, SEK, CZK) make
+     * Shopware round the line tax to whole numbers: a 678.00 line at 23% stores 127.00
+     * instead of 126.78. Mollie validates vatAmount === totalAmount * vatRate / (100 + vatRate)
+     * and rejects the payment ("The 'vatAmount' field is off. Expected to be PLN 126.78 ...,
+     * got PLN 127.00"). The vatAmount must be derived from the transmitted totalAmount
+     * whenever the Shopware value breaks that invariant.
+     */
+    public function testVatAmountIsDerivedWhenShopwareRoundedTaxBreaksTheMollieInvariant(): void
+    {
+        $orderLineItem = $this->orderRepository->getLineItemWithWholeNumberRoundedTax();
+        $currency = new CurrencyEntity();
+        $currency->setIsoCode('PLN');
+
+        $actual = LineItem::fromOrderLine($orderLineItem, $currency);
+
+        $this->assertSame(126.78, $actual->getVatAmount()->getValue());
+        $this->assertSame('23', $actual->getVatRate());
+        $this->assertSame(678.0, $actual->getAmount()->getValue());
+
+        // the invariant Mollie enforces, computed on the serialized 2-decimal values
+        $payload = $actual->jsonSerialize();
+        $vatRate = (float) $payload['vatRate'];
+        $totalAmount = (float) $payload['totalAmount']->jsonSerialize()['value'];
+        $vatAmount = (float) $payload['vatAmount']->jsonSerialize()['value'];
+
+        $this->assertSame(round($totalAmount * $vatRate / (100 + $vatRate), 2), $vatAmount);
+    }
+
     public function testCanCreateFromOrderLineWithMixedVoucherCategories(): void
     {
         $orderLineItem = $this->orderRepository->getLineItemWithMixedVoucherCategories();

--- a/tests/Unit/Payment/PayloadBuilderTest.php
+++ b/tests/Unit/Payment/PayloadBuilderTest.php
@@ -95,9 +95,11 @@ final class PayloadBuilderTest extends TestCase
                 [
                     'type' => 'digital',
                     'vatRate' => '19',
+                    // the fixture tax (19% of the gross 10.99) breaks the vatAmount invariant
+                    // Mollie enforces, so it is derived from the totalAmount: 10.99 * 19 / 119
                     'vatAmount' => [
                         'currency' => 'EUR',
-                        'value' => '2.09',
+                        'value' => '1.75',
                     ],
                     'sku' => 'SW1000',
                     'description' => 'Fake product',
@@ -114,9 +116,10 @@ final class PayloadBuilderTest extends TestCase
                 [
                     'type' => 'shipping_fee',
                     'vatRate' => '19',
+                    // derived like above: 4.99 * 19 / 119
                     'vatAmount' => [
                         'currency' => 'EUR',
-                        'value' => '0.95',
+                        'value' => '0.80',
                     ],
                     'sku' => 'mol-delivery-fake-shipping-method-id',
                     'description' => 'DHL',


### PR DESCRIPTION
## Problem

Currencies configured with **zero item-rounding decimals** (a common setup for PLN, SEK, CZK, DKK to display whole amounts) make Shopware round line taxes to whole numbers. A 678.00 PLN line at 23% VAT stores a calculated tax of **127.00** instead of 126.78.

Since v5 sends Shopware's `CalculatedTax` value as `vatAmount` unchanged, Mollie rejects the payment on every such order:

```
Line item 1 is invalid. The 'vatAmount' field is off.
Expected to be PLN 126.78 (PLN 678.00 × (23.00 / 123.00)), got PLN 127.00
```

Checkout fails for **every** order in such a currency (real-world example above is from our production shop, order lines: 678/162/315/92/136/297 PLN, taxes stored as 127/30/59/17/25/56). v4 was not affected because `PriceCalculator` always derived the vatAmount from the gross amount.

The `RoundingDifferenceFixer` does not help here — it only balances the order total with an extra 0% line, it never touches the per-line `vatAmount`.

## Fix

In `LineItem::createBaseLineItem()` the vatAmount is checked against the invariant Mollie enforces, computed on the transmitted (currency-precision rounded) values:

```
vatAmount === totalAmount × vatRate / (100 + vatRate)
```

If the Shopware tax satisfies the invariant it is passed through unchanged (keeping the behaviour of #1323 — the real summed tax is sent for blended-rate lines). Only when it breaks the invariant is the vatAmount derived from the transmitted totalAmount, like v4 did.

## Tests

- New regression test `testVatAmountIsDerivedWhenShopwareRoundedTaxBreaksTheMollieInvariant` with a PLN-style whole-number-rounded tax fixture.
- `testBlendedTaxForNetDiscountIsConsistentWithGrossAmount` is untouched and still passes (consistent taxes are not modified).
- The expected payload in `PayloadBuilderTest` was updated: the fixture computes its tax as 19% of the gross amount (10.99 → 2.09), which itself breaks Mollie's invariant — such a payload would be rejected by the live API. With this fix it is corrected to the derived value (1.75 / 0.80).
- Full unit suite: 821 tests, 2126 assertions, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)