### PR TITLE
NTR: enforce frontend norm with classes

### DIFF
--- a/config/.stylelintrc
+++ b/config/.stylelintrc
@@ -10,6 +10,12 @@
     "rules": {
         "no-missing-end-of-source-newline": true,
         "selector-class-pattern": "",
+        "selector-disallowed-list": [
+            ["/\\.js-/"],
+            {
+                "message": "js- classes are JS/test hooks only and must not be used for styling. Use a dedicated custom class instead."
+            }
+        ],
         "property-no-unknown": [
             true,
             {

--- a/src/Resources/app/storefront/src/scss/display.scss
+++ b/src/Resources/app/storefront/src/scss/display.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable selector-id-pattern, declaration-no-important */
 .mollie-express-button.d-none,
-.js-apple-pay .d-none,
-.js-apple-pay-container .d-none,
+.mollie-apple-pay-direct-button .d-none,
+.mollie-apple-pay-direct-container .d-none,
 .mollie-pos-terminals .d-none,
 .mollie-components-credit-card .d-none,
 #mollieCreditCardMandateDeleteError .d-none,

--- a/src/Resources/views/mollie/component/apple-pay-direct-button.html.twig
+++ b/src/Resources/views/mollie/component/apple-pay-direct-button.html.twig
@@ -30,7 +30,7 @@
                 locale="{{ app.request.locale }}"
                 data-shop-url="{{ seoUrl('frontend.home.page') }}"
                 data-applepay-enabled="{{ mollie_applepaydirect_enabled }}"
-                class="js-apple-pay mollie-express-button w-100 d-none"></apple-pay-button>
+                class="js-apple-pay mollie-express-button mollie-apple-pay-direct-button w-100 d-none"></apple-pay-button>
         {% endblock %}
     </div>
 {% endblock %}

--- a/src/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
+++ b/src/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
@@ -40,7 +40,7 @@
 
         {% if applePayVisible %}
             {% block page_product_detail_buy_container_apple_direct_component %}
-                <div class="row g-2 form-row mt-2 justify-content-end js-apple-pay-container mollie-apple-pay-direct-pdp d-none">
+                <div class="row g-2 form-row mt-2 justify-content-end js-apple-pay-container mollie-apple-pay-direct-container mollie-apple-pay-direct-pdp d-none">
                     {% include '@MolliePayments/mollie/component/apple-pay-direct-button.html.twig' with {cols: 'col-8'} %}
                 </div>
             {% endblock %}

--- a/src/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
+++ b/src/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
@@ -14,7 +14,7 @@
 
         {% if applePayVisible %}
             {% block component_offcanvas_cart_actions_checkout_apple_direct_component %}
-                <div class="mt-2 js-apple-pay-container mollie-apple-pay-direct-offcanvas d-none">
+                <div class="mt-2 js-apple-pay-container mollie-apple-pay-direct-container mollie-apple-pay-direct-offcanvas d-none">
                     {% include '@MolliePayments/mollie/component/apple-pay-direct-button.html.twig' %}
                 </div>
             {% endblock %}

--- a/src/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Resources/views/storefront/component/product/card/action.html.twig
@@ -26,7 +26,7 @@
 
         {% if applePayVisible %}
             {% block component_product_box_action_buy_apple_direct_component %}
-                <div class="mt-2 js-apple-pay-container mollie-apple-pay-direct-listing d-none">
+                <div class="mt-2 js-apple-pay-container mollie-apple-pay-direct-container mollie-apple-pay-direct-listing d-none">
                     {% include '@MolliePayments/mollie/component/apple-pay-direct-button.html.twig' %}
                 </div>
             {% endblock %}

--- a/src/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -46,7 +46,7 @@
 
     {% if applePayVisible %}
         {% block page_checkout_aside_actions_apple_direct_component %}
-            <div class="mt-2 js-apple-pay-container mollie-apple-pay-direct-cart d-none">
+            <div class="mt-2 js-apple-pay-container mollie-apple-pay-direct-container mollie-apple-pay-direct-cart d-none">
                 {% include '@MolliePayments/mollie/component/apple-pay-direct-button.html.twig' %}
             </div>
         {% endblock %}

--- a/src/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -30,7 +30,7 @@
     {% block page_product_detail_buy_container_apple_direct %}
         {% if applePayVisible %}
             {% block page_product_detail_buy_container_apple_direct_component %}
-                <div class="row g-2 form-row mt-2 justify-content-end js-apple-pay-container mollie-apple-pay-direct-pdp d-none">
+                <div class="row g-2 form-row mt-2 justify-content-end js-apple-pay-container mollie-apple-pay-direct-container mollie-apple-pay-direct-pdp d-none">
                     {% include '@MolliePayments/mollie/component/apple-pay-direct-button.html.twig' with {cols: 'col-8'} %}
                 </div>
             {% endblock %}


### PR DESCRIPTION
## `js-` classes are JS/test hooks only, not styling hooks

### Why
Per our frontend norm, `js-` prefixed classes are reserved as JavaScript/Cypress selectors and must not be used for styling. `display.scss` violated this by styling via `.js-apple-pay` and `.js-apple-pay-container`.

### Changes
- **`display.scss`**: replaced the `js-` styling selectors with dedicated custom classes:
  - `.js-apple-pay .d-none` → `.mollie-apple-pay-direct-button .d-none`
  - `.js-apple-pay-container .d-none` → `.mollie-apple-pay-direct-container .d-none`
- **Templates**: added the new styling classes without removing the `js-` hooks:
  - `mollie-apple-pay-direct-button` on the `<apple-pay-button>` (apple-pay-direct-button.html.twig)
  - `mollie-apple-pay-direct-container` on all 5 Apple Pay container divs (offcanvas, pdp ×2, listing, cart)
- **`config/.stylelintrc`**: added a `selector-disallowed-list` rule that forbids `js-` classes in selectors, so future violations fail linting automatically.

### Notes
- `js-` classes and the context-specific classes (`-offcanvas`, `-pdp`, `-cart`, `-listing`) are kept — JS (`buy-box-repository.js`) and Cypress selectors are untouched.
- Did **not** reuse the existing `.mollie-express-button` for the button, since that class also sits on the PayPal button — a dedicated class keeps the selector scope identical to before.