### PR TITLE
NTR: reduce fragile storefront template overrides

### DIFF
--- a/src/Resources/views/storefront/page/checkout/address/register.html.twig
+++ b/src/Resources/views/storefront/page/checkout/address/register.html.twig
@@ -11,8 +11,19 @@
      {% endfor %}
 
      {% if(isMollieSubscription == true) %}
-         {# we must require a registration, so hide the "do not create customer" checkbox #}
-         {# but the form field is still required to be true, otherwise we continue as guest #}
+         {# Subscriptions require a real customer account. Correctness is already
+            enforced server-side by SubscriptionCartValidator, which adds a
+            blocking InvalidGuestAccountError for guest carts containing a
+            subscription. This block only handles the UX: hide the guest option
+            so the customer never runs into that block.
+
+            We still render parent() (visually hidden) instead of dropping it, so
+            that other plugins/themes extending this same block keep their output.
+            The core guest checkbox stays unchecked and therefore submits nothing;
+            our hidden field then forces createCustomerAccount to true. #}
+         <div class="d-none" aria-hidden="true">
+             {{ parent() }}
+         </div>
          <input type="hidden" name="createCustomerAccount" value="true">
      {% else %}
          {{ parent() }}

--- a/src/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -14,26 +14,6 @@
     {{ parent() }}
 {% endblock %}
 
-{% block page_checkout_cart_shipping_costs_form_group_payment_method %}
-
-    <div class="form-group">
-        <label for="paymentMethodId">{{ "checkout.paymentMethod"|trans|sw_sanitize }}</label>
-        <select class="custom-select form-select" type="text" id="paymentMethodId" name="paymentMethodId">
-            {% for payment in page.paymentMethods %}
-                <option value="{{ payment.id }}"
-                        {% if payment.id == context.paymentMethod.id %} selected="selected"{% endif %}>
-                    {{ payment.translated.name }}
-
-                    {% if "Mollie" in payment.handlerIdentifier and page.isMollieTestMode == true %}
-                        ({{ "molliePayments.testMode.label"|trans }})
-                    {% endif %}
-                </option>
-            {% endfor %}
-        </select>
-    </div>
-{% endblock %}
-
-
 {% block page_checkout_aside_actions %}
     {{ parent() }}
 

--- a/tests/Cypress/cypress/e2e/storefront/subscriptions/subscription-guest-checkout.cy.js
+++ b/tests/Cypress/cypress/e2e/storefront/subscriptions/subscription-guest-checkout.cy.js
@@ -1,0 +1,105 @@
+import Devices from "Services/utils/Devices";
+import Session from "Services/utils/Session";
+// ------------------------------------------------------
+import ShopConfigurationAction from "Actions/admin/ShopConfigurationAction";
+import PDPAction from "Actions/storefront/products/PDPAction";
+import MollieProductsAction from "Actions/storefront/products/MollieProductsAction";
+import RegisterRepository from "Repositories/storefront/checkout/RegisterRepository";
+import ShopConfiguration from "../../../support/models/ShopConfiguration";
+import PluginConfiguration from "../../../support/models/PluginConfiguration";
+
+
+const devices = new Devices();
+const session = new Session();
+
+const configAction = new ShopConfigurationAction();
+const pdp = new PDPAction();
+const mollieProducts = new MollieProductsAction();
+
+const repoRegister = new RegisterRepository();
+
+const testDevices = [devices.getFirstDevice()];
+
+
+let beforeAllCalled = false;
+
+function beforeEach(device) {
+    cy.wrap(null).then(() => {
+        if (!beforeAllCalled) {
+
+            const shopConfig = new ShopConfiguration();
+
+            const pluginConfig = new PluginConfiguration();
+            pluginConfig.setSubscriptionIndicator(true);
+
+            configAction.configureEnvironment(shopConfig, pluginConfig);
+
+            beforeAllCalled = true;
+        }
+        devices.setDevice(device);
+        // reset session so every test starts as an anonymous (not logged in) guest
+        session.resetBrowserSession();
+    });
+}
+
+
+describe('Subscription - Guest Checkout', () => {
+
+    testDevices.forEach(device => {
+
+        context(devices.getDescription(device), () => {
+
+            describe('Storefront', () => {
+
+                // TODO: prefix the test name with the TestRail case id (e.g. "C123456: ...") once created
+                it('Subscription in cart forces account creation on the guest checkout page', () => {
+
+                    beforeEach(device);
+
+                    // add a subscription product to the cart as an anonymous visitor
+                    mollieProducts.openSubscriptionProduct_Weekly3();
+                    cy.contains('.btn', 'Subscribe');
+                    pdp.addToCart(1);
+
+                    // open the checkout register page (still not logged in)
+                    cy.visit('/checkout/register');
+                    cy.url().should('include', '/checkout/register');
+
+                    // our override must inject the hidden field that forces account creation
+                    repoRegister.getForcedCreateAccountInput()
+                        .should('exist')
+                        .and('have.value', 'true');
+
+                    // and the customer must NOT see a toggle to continue as guest:
+                    // the core checkbox is preserved (parent()) but visually hidden
+                    repoRegister.getVisibleCreateAccountControls().should('not.exist');
+
+                    // the register form itself must still render normally
+                    repoRegister.getRegisterSubmitButton().should('be.visible');
+                })
+
+                // TODO: prefix the test name with the TestRail case id (e.g. "C123456: ...") once created
+                it('Regular cart keeps the guest checkout option available', () => {
+
+                    beforeEach(device);
+
+                    // add a regular (non-subscription) product to the cart as a guest
+                    mollieProducts.openRegularProduct();
+                    pdp.addToCart(1);
+
+                    cy.visit('/checkout/register');
+                    cy.url().should('include', '/checkout/register');
+
+                    // no forced field, because there is no subscription in the cart
+                    repoRegister.getForcedCreateAccountInput().should('not.exist');
+
+                    // the standard "create a customer account" control is visible and usable
+                    repoRegister.getVisibleCreateAccountControls().should('exist');
+
+                    repoRegister.getRegisterSubmitButton().should('be.visible');
+                })
+
+            })
+        })
+    })
+})

--- a/tests/Cypress/cypress/support/repositories/storefront/checkout/RegisterRepository.js
+++ b/tests/Cypress/cypress/support/repositories/storefront/checkout/RegisterRepository.js
@@ -8,4 +8,38 @@ export default class RegisterRepository {
     getPayPalExpressButton(){
         return cy.get('.mollie-paypal-express-register button[name="paypal-express"]');
     }
+
+    /**
+     * The hidden field our template override injects when the cart contains a
+     * subscription: it forces account creation and only exists in that case.
+     * @returns {Cypress.Chainable<JQuery<HTMLElement>>}
+     */
+    getForcedCreateAccountInput() {
+        return cy.get('input[type="hidden"][name="createCustomerAccount"][value="true"]');
+    }
+
+    /**
+     * All "create a customer account" controls, regardless of visibility.
+     * @returns {Cypress.Chainable<JQuery<HTMLElement>>}
+     */
+    getCreateAccountControls() {
+        return cy.get('[name="createCustomerAccount"]');
+    }
+
+    /**
+     * Only the "create a customer account" controls the customer can actually
+     * interact with. In the subscription case the core checkbox is wrapped in a
+     * hidden container and must not appear here.
+     * @returns {Cypress.Chainable<JQuery<HTMLElement>>}
+     */
+    getVisibleCreateAccountControls() {
+        return cy.get('[name="createCustomerAccount"]:visible');
+    }
+
+    /**
+     * @returns {Cypress.Chainable<JQuery<HTMLElement>>}
+     */
+    getRegisterSubmitButton() {
+        return cy.get('.register-submit > .btn, .register-submit .btn');
+    }
 }


### PR DESCRIPTION
Reviewed all 27 storefront template overrides. Most already use sw_extends + {{ parent() }} (inheritance-safe, no change needed). Only two overrides replaced core blocks without parent() — those are addressed here.

## Why
Minimize template footprint and keep customer-theme inheritance intact, without losing behavior.

## Changes
- **Cart payment select (`page/checkout/cart/index.html.twig`):** removed the page_checkout_cart_shipping_costs_form_group_payment_method override. It fully re-rendered the core `<select>` only to append a (Test Mode) label whose condition (page.isMollieTestMode) is never set anywhere — dead code. Removing it restores the native core select and drops the most fragile, clobber-prone override. No functional change.
- **Guest checkbox for subscriptions (`page/checkout/address/register.html.twig`):** the subscription branch no longer drops parent(). The core guest control is now preserved (wrapped in d-none) so other plugins/themes extending the same block keep their output; correctness is still enforced server-side by SubscriptionCartValidator (InvalidGuestAccountError, blockOrder=true). Template now only handles UX.
- **Cypress:** added `subscription-guest-checkout.cy.js` covering both paths — subscription in cart forces account creation / regular cart keeps the guest option — plus supporting selectors in the checkout RegisterRepository.