### PR TITLE
Fix: truncate billing address title to Mollie's 20 character limit

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Behoben: Die Erfassung beim Versand sendet für Netto-Kunden nun den Bruttobetrag.
+- Behoben: Anreden mit mehr als 20 Zeichen brechen die Zahlungserstellung nicht mehr ab; der Adress-Titel wird nun auf Mollies 20-Zeichen-Limit gekürzt.
 
 # 5.3.0
 - Hinzugefügt: Bestellungen können über einen Mollie-Payment-Link (Route `mollie.pay`) bezahlt werden, nutzbar in E-Mail-Templates, z. B. `{{ rawUrl('mollie.pay', { 'orderId': order.id }, salesChannel.domains|first.url) }}`.

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Fixed: Shipment capture now sends the gross amount for net-tax customers.
+- Fixed: Salutations longer than 20 characters no longer abort payment creation; the address title is now truncated to Mollie's 20 character limit.
 
 # 5.3.0
 - Added: Orders can be paid via a Mollie payment link (route `mollie.pay`), which can be used in email templates, e.g. `{{ rawUrl('mollie.pay', { 'orderId': order.id }, salesChannel.domains|first.url) }}`.

--- a/shopware/Component/Mollie/Address.php
+++ b/shopware/Component/Mollie/Address.php
@@ -12,6 +12,13 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 final class Address implements \JsonSerializable
 {
     public const CUSTOM_FIELDS_KEY = 'mollie_payments_express_address_id';
+
+    /**
+     * Maximum length Mollie accepts for the address "title" field. Longer values are
+     * rejected with an "Unprocessable Entity" error and abort the whole payment creation.
+     */
+    private const MAX_TITLE_LENGTH = 20;
+
     private string $title;
     private string $givenName;
     private string $familyName;
@@ -148,7 +155,7 @@ final class Address implements \JsonSerializable
     public function jsonSerialize(): array
     {
         $data = [
-            'title' => trim($this->title),
+            'title' => $this->limitTitle(trim($this->title)),
             'givenName' => trim($this->givenName),
             'familyName' => trim($this->familyName),
             'streetAndNumber' => trim($this->streetAndNumber),
@@ -214,6 +221,20 @@ final class Address implements \JsonSerializable
         }
 
         $this->phone = PhoneNumber::toE164($phone, $this->country);
+    }
+
+    /**
+     * The salutation display name is used as the Mollie "title". Some (especially
+     * localized) salutations are longer than Mollie's 20 character limit and would
+     * abort the payment, so the value is trimmed down to the accepted length.
+     */
+    private function limitTitle(string $title): string
+    {
+        if (mb_strlen($title) > self::MAX_TITLE_LENGTH) {
+            return mb_substr($title, 0, self::MAX_TITLE_LENGTH);
+        }
+
+        return $title;
     }
 
     public function getTitle(): string

--- a/tests/Unit/Mollie/AddressTest.php
+++ b/tests/Unit/Mollie/AddressTest.php
@@ -107,6 +107,26 @@ final class AddressTest extends TestCase
         $this->assertArrayNotHasKey('phone', $actual);
     }
 
+    public function testJsonSerializeTruncatesTitleToMollieLimit(): void
+    {
+        // Mollie rejects a "title" longer than 20 characters with an Unprocessable Entity error.
+        $address = new Address(
+            'fake@unit.test',
+            'This salutation is way too long',
+            'Tester',
+            'Test',
+            'Test Street',
+            '12345',
+            'Test City',
+            'DE'
+        );
+
+        $actual = $address->jsonSerialize();
+
+        $this->assertSame('This salutation is w', $actual['title']);
+        $this->assertLessThanOrEqual(20, mb_strlen($actual['title']));
+    }
+
     public function testExpectExceptionOnEmptySalutation()
     {
         $customer = $this->customerRepository->getDefaultCustomerWithoutSalutation();


### PR DESCRIPTION
### What does this PR do?

Fixes payment creation failing when a customer's salutation (address `title`) is longer than 20 characters.

Mollie's Payments API rejects an address `title` longer than 20 characters with:

```
{"title":"Unprocessable Entity","error":"The 'title' field should not be longer than 20 characters","field":"billingAddress.title"}
```

Since the `title` is derived from the salutation display name (`Address::fromAddress()` → `$salutation->getDisplayName()`), any salutation longer than 20 characters aborts the whole checkout.

`Address::jsonSerialize()` now truncates the `title` to Mollie's accepted length (`MAX_TITLE_LENGTH = 20`) before sending it. All other behaviour is unchanged.

### How to test

- Configure/use a salutation whose display name is longer than 20 characters.
- Place an order using a Mollie payment method — previously this failed with the "title should not be longer than 20 characters" error; now checkout succeeds and the title is sent truncated to 20 characters.
- `AddressTest::testJsonSerializeTruncatesTitleToMollieLimit` covers the truncation.

### Related issue

Fixes #1408

🤖 Generated with [Claude Code](https://claude.com/claude-code)