### PR TITLE
Only check mollie order's for changed delivery state

### DIFF
--- a/shopware/Component/Shipment/OrderDeliverySubscriber.php
+++ b/shopware/Component/Shipment/OrderDeliverySubscriber.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Mollie\Shopware\Component\Shipment;
 
+use Mollie\Shopware\Component\Mollie\Payment;
 use Mollie\Shopware\Component\Settings\AbstractSettingsService;
 use Mollie\Shopware\Component\Settings\SettingsService;
 use Mollie\Shopware\Component\Shipment\Route\AbstractShipOrderRoute;
 use Mollie\Shopware\Component\Shipment\Route\ShipOrderRoute;
+use Mollie\Shopware\Component\Transaction\MollieOrderTransactionCollection;
+use Mollie\Shopware\Mollie;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
@@ -57,19 +61,27 @@ final class OrderDeliverySubscriber implements EventSubscriberInterface
         $orderDeliveryId = $event->getTransition()->getEntityId();
 
         $criteria = new Criteria([$orderDeliveryId]);
-        $criteria->addAssociation('order');
+        $criteria->addAssociation('order.transactions.stateMachineState');
 
         $orderDelivery = $this->orderDeliveryRepository->search($criteria, $context)->first();
         if (! $orderDelivery instanceof OrderDeliveryEntity) {
-            $this->logger->error('Delivery not found for ' . $orderDeliveryId);
-
             return;
         }
 
         $order = $orderDelivery->getOrder();
         if ($order === null) {
-            $this->logger->error('Order association missing for delivery ' . $orderDeliveryId);
+            return;
+        }
 
+        $transactions = new MollieOrderTransactionCollection($order->getTransactions());
+        $transaction = $transactions->getCurrentOrderTransaction();
+        if (! $transaction instanceof OrderTransactionEntity) {
+            return;
+        }
+
+        /** @var ?Payment $molliePayment */
+        $molliePayment = $transaction->getExtension(Mollie::EXTENSION);
+        if (! $molliePayment instanceof Payment) {
             return;
         }
 

--- a/tests/Unit/Shipment/OrderDeliverySubscriberTest.php
+++ b/tests/Unit/Shipment/OrderDeliverySubscriberTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Mollie\Shopware\Unit\Shipment;
 
+use Mollie\Shopware\Component\Mollie\Payment;
 use Mollie\Shopware\Component\Settings\Struct\PaymentSettings;
 use Mollie\Shopware\Component\Shipment\OrderDeliverySubscriber;
+use Mollie\Shopware\Mollie;
 use Mollie\Shopware\Unit\Fake\FakeEntityRepository;
 use Mollie\Shopware\Unit\Fake\FakeSettingsService;
 use Mollie\Shopware\Unit\Fake\FakeShipOrderRoute;
@@ -14,6 +16,8 @@ use Psr\Log\NullLogger;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -127,6 +131,20 @@ class OrderDeliverySubscriberTest extends TestCase
         $order->setId('fakeshopwareorderid');
         $order->setOrderNumber('10000');
         $order->setSalesChannelId(TestDefaults::SALES_CHANNEL);
+
+        $state = new StateMachineStateEntity();
+        $state->setId('paid-state-id');
+        $state->setTechnicalName('paid');
+
+        $orderTransaction = new OrderTransactionEntity();
+        $orderTransaction->setId('fakeshopwaretransactionid');
+        $orderTransaction->setOrderId($order->getId());
+        $orderTransaction->setStateMachineState($state);
+        $orderTransaction->setCustomFields([
+            Mollie::EXTENSION => new Payment('fake-mollie-payment-id'),
+        ]);
+
+        $order->setTransactions(new OrderTransactionCollection([$orderTransaction]));
 
         return $order;
     }


### PR DESCRIPTION
- The subscriber fails at `repairLegacyTransaction`, if there are order deliveries from other payment providers which do not have mollie data at all
- We now check, if it is a mollie order before using the ShipOrderRoute