### PR TITLE
Fix OrderFileHandler incorrect log level & increase non debug log level to warning

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,7 @@
 # Unreleased
 - Geändert: In Headless-Setups werden die Store-API-Webhook- und Return-URLs nun aus APP_URL statt aus dem Proxy-Host gebildet, damit Mollie sie erreichen kann.
+- Geändert: Das Log-Level wurde für den deaktivierten Debug-Modus der Einstellungen wurden von `INFO` zu `WARNING` geändert, um Spam in Logdateien zu verhindern.
+- Behoben: Das Log-Level für Order-bezogene Logeinträge verwendet nun das korrekte Log-Level der Debug-Modus Einstellung (`DEBUG` oder `WARNING`).
 - Behoben: Die Erfassung beim Versand sendet für Netto-Kunden nun den Bruttobetrag.
 - Behoben: Anreden mit mehr als 20 Zeichen brechen die Zahlungserstellung nicht mehr ab; der Adress-Titel wird nun auf Mollies 20-Zeichen-Limit gekürzt.
 - Behoben: Der automatische Versand beim Wechsel des Lieferstatus läuft nun nur noch für über Mollie bezahlte Bestellungen.

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,5 +1,7 @@
 # Unreleased
 - Changed: In headless setups the store-api webhook and return URLs are now built from APP_URL instead of the proxy host, so Mollie can reach them.
+- Changed: The log level for the disabled debug mode of the settings was changed from `INFO` to `WARNING` to prevent spam in log files.
+- Fixed: The log level for order-related log entries now uses the correct log level from the debug mode setting (`DEBUG` or `WARNING`).
 - Fixed: Shipment capture now sends the gross amount for net-tax customers.
 - Fixed: Salutations longer than 20 characters no longer abort payment creation; the address title is now truncated to Mollie's 20 character limit.
 - Fixed: Automatic shipment on delivery state change now only runs for orders paid via Mollie.

--- a/shopware/Component/Logger/OrderFileHandler.php
+++ b/shopware/Component/Logger/OrderFileHandler.php
@@ -3,15 +3,19 @@ declare(strict_types=1);
 
 namespace Mollie\Shopware\Component\Logger;
 
+use Mollie\Shopware\Component\Settings\AbstractSettingsService;
+use Mollie\Shopware\Component\Settings\SettingsService;
 use Monolog\Handler\AbstractHandler;
 use Monolog\Handler\StreamHandler;
-use Monolog\Level;
 use Monolog\LogRecord;
 use Psr\Log\LogLevel;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class OrderFileHandler extends AbstractHandler
 {
     public function __construct(
+        #[Autowire(service: SettingsService::class)]
+        private AbstractSettingsService $settingsService,
         private OrderLogStorage $storage,
         bool $bubble = false
     ) {
@@ -34,13 +38,15 @@ final class OrderFileHandler extends AbstractHandler
 
         $orderLogPath = $this->storage->resolveLogFile($orderNumber);
 
+        $loggerSettings = $this->settingsService->getLoggerSettings();
+        $logLevel = $loggerSettings->isDebugMode() ? LogLevel::DEBUG : LogLevel::WARNING;
+
         try {
-            $handler = new StreamHandler($orderLogPath, LogLevel::DEBUG);
-            $handler->handle($record);
-        } catch (\Exception $e) {
+            $handler = new StreamHandler($orderLogPath, $logLevel, $this->bubble);
+
+            return $handler->handle($record);
+        } catch (\Exception) {
             return false;
         }
-
-        return $record->level->value < Level::Warning->value;
     }
 }

--- a/shopware/Component/Logger/PluginSettingsHandler.php
+++ b/shopware/Component/Logger/PluginSettingsHandler.php
@@ -71,7 +71,7 @@ final class PluginSettingsHandler extends AbstractHandler
     {
         $loggerSettings = $this->settingsService->getLoggerSettings();
 
-        $logLevel = $loggerSettings->isDebugMode() ? LogLevel::DEBUG : LogLevel::INFO;
+        $logLevel = $loggerSettings->isDebugMode() ? LogLevel::DEBUG : LogLevel::WARNING;
         $maxFiles = $loggerSettings->getLogFileDays();
 
         return new RotatingFileHandler($this->filePath, $maxFiles, $logLevel);


### PR DESCRIPTION
- The OrderFileHandler currently doesn't use the correct log level from the plugin settings, but always debug right now
- With a disabled debug mode in the settings the log level should be `warning` instead of `info` as the `info` log level spam's the logs a lot