### PR TITLE
NTR: frontend cleanup - SCSS variables & inline styles

### DIFF
--- a/src/Resources/app/storefront/src/scss/abstract/_variables.scss
+++ b/src/Resources/app/storefront/src/scss/abstract/_variables.scss
@@ -1,0 +1,35 @@
+// Mollie storefront brand tokens.
+//
+// These are colors that do NOT map to a Bootstrap/Shopware theme variable
+// (brand colors of Mollie, PayPal and the subscription status badges). Anything
+// that maps cleanly to a theme variable ($white, $black, $danger, ...) uses that
+// variable directly and is not duplicated here.
+//
+// This file must be imported first in base.scss so the tokens are available to
+// all component partials.
+
+// PayPal Express button themes (official PayPal brand colors)
+$mollie-paypal-gold: #ffc439;
+$mollie-paypal-gold-hover: #fcc85b;
+$mollie-paypal-blue: #009cde;
+$mollie-paypal-blue-hover: #09adf3;
+$mollie-paypal-silver: #eee;
+$mollie-paypal-silver-hover: #f6f6f6;
+$mollie-paypal-silver-border: #f6f6f6;
+$mollie-paypal-white-border: #f3f3f3;
+$mollie-paypal-white-hover: #f3f3f3;
+$mollie-paypal-black-border: #555;
+$mollie-paypal-black-hover: #333;
+
+// Subscription status badge colors (account order overview)
+$mollie-subscription-active: #0042a0;
+$mollie-subscription-canceled: #b30000;
+$mollie-subscription-paused: #595959;
+$mollie-subscription-skipped: #ffb100;
+
+// Mollie Components credit card iframe fields
+$mollie-cc-error: #ff233a;
+$mollie-cc-error-shadow: #f33;
+$mollie-cc-error-bg: #fff0f0;
+$mollie-cc-focus: #07f;
+$mollie-cc-input-color: #262626;

--- a/src/Resources/app/storefront/src/scss/account/order.scss
+++ b/src/Resources/app/storefront/src/scss/account/order.scss
@@ -3,32 +3,32 @@
 }
 
 .order-item-status-badge.order-item-status-badge-active {
-    background-color: #0042a0;
-    color: #fff;
+    background-color: $mollie-subscription-active;
+    color: $white;
     margin: 10px 0;
 }
 
 .order-item-status-badge.order-item-status-badge-canceled {
-    background-color: #b30000;
-    color: #fff;
+    background-color: $mollie-subscription-canceled;
+    color: $white;
     margin: 10px 0;
 }
 
 .order-item-status-badge.order-item-status-badge-paused {
-    background-color: #595959;
-    color: #fff;
+    background-color: $mollie-subscription-paused;
+    color: $white;
     margin: 10px 0;
 }
 
 .order-item-status-badge.order-item-status-badge-skipped {
-    background-color: #ffb100;
-    color: #000;
+    background-color: $mollie-subscription-skipped;
+    color: $black;
     margin: 10px 0;
 }
 
 .order-item-status-badge.order-item-status-badge-resumed {
-    background-color: #0042a0;
-    color: #fff;
+    background-color: $mollie-subscription-active;
+    color: $white;
     margin: 10px 0;
 }
 

--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,3 +1,4 @@
+@import './abstract/variables';
 @import './account/order';
 @import './component/apple-pay-direct';
 @import './component/credit-card-components';

--- a/src/Resources/app/storefront/src/scss/component/credit-card-components.scss
+++ b/src/Resources/app/storefront/src/scss/component/credit-card-components.scss
@@ -45,7 +45,7 @@
 }
 
 .mollie-components-credit-card .error-message {
-    color: #ff233a;
+    color: $mollie-cc-error;
     margin-bottom: 5px;
 }
 
@@ -53,40 +53,40 @@
     border-radius: 3px;
     min-height: 34px;
     margin-bottom: 5px;
-    background: #fff;
-    color: #262626;
+    background: $white;
+    color: $mollie-cc-input-color;
     text-align: left;
     box-shadow:
         inset 0 0 0 0 transparent,
-        0 1px 1px 0 rgb(0 0 0 / 10%),
-        0 1px 3px 0 rgb(0 0 0 / 10%),
-        0 0 0 1px rgb(0 0 0 / 5%);
+        0 1px 1px 0 rgba($black, 0.1),
+        0 1px 3px 0 rgba($black, 0.1),
+        0 0 0 1px rgba($black, 0.05);
     transition: all 0.05s ease;
 }
 
 .mollie-components-credit-card .input--field.mollie.is-focused {
     box-shadow:
-        inset 0 0 0 2px #07f,
-        0 1px 1px 0 rgb(0 0 0 / 10%),
-        0 2px 6px 0 rgb(0 0 0 / 10%),
-        0 0 0 1px rgb(0 0 0 / 5%);
+        inset 0 0 0 2px $mollie-cc-focus,
+        0 1px 1px 0 rgba($black, 0.1),
+        0 2px 6px 0 rgba($black, 0.1),
+        0 0 0 1px rgba($black, 0.05);
 }
 
 .mollie-components-credit-card .input--field.mollie.error {
-    background-color: #fff0f0;
+    background-color: $mollie-cc-error-bg;
     box-shadow:
-        0 0 0 1px #f33,
-        0 1px 1px 0 rgb(0 0 0 / 10%),
-        0 2px 6px 0 rgb(0 0 0 / 10%),
-        0 0 0 1px rgb(0 0 0 / 5%);
+        0 0 0 1px $mollie-cc-error-shadow,
+        0 1px 1px 0 rgba($black, 0.1),
+        0 2px 6px 0 rgba($black, 0.1),
+        0 0 0 1px rgba($black, 0.05);
 }
 
 .mollie-components-credit-card .input--field.mollie:active {
     box-shadow:
-        0 1px 1px 0 rgb(0 0 0 / 10%),
-        0 2px 6px 0 rgb(0 0 0 / 10%),
-        0 0 0 1px rgb(0 0 0 / 5%);
-    border: 2px solid #07f;
+        0 1px 1px 0 rgba($black, 0.1),
+        0 2px 6px 0 rgba($black, 0.1),
+        0 0 0 1px rgba($black, 0.05);
+    border: 2px solid $mollie-cc-focus;
 }
 
 .mollie-components-credit-card .block-group .mollie-credit-card-custom-checkbox {

--- a/src/Resources/app/storefront/src/scss/component/credit-card-mandate.scss
+++ b/src/Resources/app/storefront/src/scss/component/credit-card-mandate.scss
@@ -28,6 +28,10 @@
 .mollie-credit-card-mandate {
     margin-bottom: 25px;
 
+    .mollie-mandate-subscription-badge {
+        margin: 0 0 0 20px;
+    }
+
     .mollie-credit-card-mandate-radio {
         margin-top: 13px;
     }

--- a/src/Resources/app/storefront/src/scss/component/payment-selection.scss
+++ b/src/Resources/app/storefront/src/scss/component/payment-selection.scss
@@ -28,7 +28,7 @@
         margin-top: 15px;
 
         .custom-select:invalid {
-            border: 1px solid red;
+            border: 1px solid $danger;
         }
     }
 
@@ -40,7 +40,7 @@
         margin-top: 15px;
 
         .custom-select:invalid {
-            border: 1px solid red;
+            border: 1px solid $danger;
         }
     }
 }

--- a/src/Resources/app/storefront/src/scss/component/paypal-express-button.scss
+++ b/src/Resources/app/storefront/src/scss/component/paypal-express-button.scss
@@ -12,6 +12,16 @@
     padding: 7px;
 }
 
+.mollie-paypal-button-image {
+    width: 80px;
+}
+
+.mollie-paypal-button-label {
+    margin: 0;
+    margin-left: 8px;
+    font-weight: 100;
+}
+
 .paypal-button-pill {
     border-radius: 30px;
 }
@@ -21,51 +31,51 @@
 }
 
 .paypal-theme-gold {
-    color: #000;
-    background-color: #ffc439ff;
-    border: 1px solid #fcc85b;
+    color: $black;
+    background-color: $mollie-paypal-gold;
+    border: 1px solid $mollie-paypal-gold-hover;
 }
 
 .paypal-theme-gold:hover {
-    background-color: #fcc85b;
+    background-color: $mollie-paypal-gold-hover;
 }
 
 .paypal-theme-blue {
-    color: #fff;
-    background-color: #009cdeff;
-    border: 1px solid #09adf3;
+    color: $white;
+    background-color: $mollie-paypal-blue;
+    border: 1px solid $mollie-paypal-blue-hover;
 }
 
 .paypal-theme-blue:hover {
-    background-color: #09adf3;
+    background-color: $mollie-paypal-blue-hover;
 }
 
 .paypal-theme-silver {
-    color: #000;
-    background-color: #eeef;
-    border: 1px solid #f6f6f6;
+    color: $black;
+    background-color: $mollie-paypal-silver;
+    border: 1px solid $mollie-paypal-silver-border;
 }
 
 .paypal-theme-silver:hover {
-    background-color: #f6f6f6;
+    background-color: $mollie-paypal-silver-hover;
 }
 
 .paypal-theme-white {
-    color: #000;
-    background-color: #fff;
-    border: 1px solid #f3f3f3;
+    color: $black;
+    background-color: $white;
+    border: 1px solid $mollie-paypal-white-border;
 }
 
 .paypal-theme-white:hover {
-    background-color: #f3f3f3;
+    background-color: $mollie-paypal-white-hover;
 }
 
 .paypal-theme-black {
-    color: #fff;
-    background-color: #000;
-    border: 1px solid #555;
+    color: $white;
+    background-color: $black;
+    border: 1px solid $mollie-paypal-black-border;
 }
 
 .paypal-theme-black:hover {
-    background-color: #333;
+    background-color: $mollie-paypal-black-hover;
 }

--- a/src/Resources/app/storefront/src/scss/component/subscriptions.scss
+++ b/src/Resources/app/storefront/src/scss/component/subscriptions.scss
@@ -44,5 +44,5 @@
 }
 
 .btn-mollie-subscription-cancel {
-    color: #b30000;
+    color: $mollie-subscription-canceled;
 }

--- a/src/Resources/views/mollie/component/credit-card-mandate.html.twig
+++ b/src/Resources/views/mollie/component/credit-card-mandate.html.twig
@@ -31,7 +31,7 @@
                                 {% endblock %}
 
                                 {% if modifiable and mandate.beingUsedForSubscription %}
-                                    <span class="badge badge-lg order-item-status-badge order-item-status-badge-canceled" style="margin:0px;margin-left:20px;">
+                                    <span class="badge badge-lg order-item-status-badge order-item-status-badge-canceled mollie-mandate-subscription-badge">
                                      {{ "molliePayments.components.mandate.subscriptionBadge"|trans|striptags }}
                                     </span>
                                 {% endif %}

--- a/src/Resources/views/mollie/component/paypal-express-button.html.twig
+++ b/src/Resources/views/mollie/component/paypal-express-button.html.twig
@@ -29,8 +29,8 @@
 
     <div class="{{ cols }}">
         <button name="paypal-express" class="mollie-paypal-button mollie-express-button paypal-button-{{ shape }} paypal-theme-{{ theme }}" data-form-action="{{ path('frontend.mollie.paypal-express.start') }}">
-            <img src="{{ image }}" width="80px;"/>
-            <p style="font-weight: 100;margin:0;margin-left:8px">Checkout</p>
+            <img src="{{ image }}" class="mollie-paypal-button-image" alt="PayPal"/>
+            <p class="mollie-paypal-button-label">Checkout</p>
             <div class="loader">
 
             </div>


### PR DESCRIPTION
Replaces hardcoded values in the storefront styles with variables and moves
inline styles out of the Twig templates.

### Changes
- **New `scss/abstract/_variables.scss`** – central brand tokens for colors that
  have no theme-variable equivalent (PayPal button themes, subscription status
  badges, credit-card field colors). Imported first in `base.scss`.
- **Hardcoded colors replaced** in `paypal-express-button`, `account/order`,
  `subscriptions`, `credit-card-components` and `payment-selection`:
  - Obvious matches now use Bootstrap/Shopware variables (`$white`, `$black`,
    `$danger`).
  - Brand colors use the new `$mollie-*` tokens.
  - `rgb(0 0 0 / X%)` shadows normalized to `rgba($black, X)`.
- **Bug fixes** carried along:
  - Invalid 4-digit hex `#eeef` → `$mollie-paypal-silver` (`#eeeeee`).
  - 8-digit hex `#ffc439ff` / `#009cdeff` → clean 6-digit values.
- **Inline styles removed from Twig:**
  - `paypal-express-button.html.twig`: `<p style=...>` and invalid
    `width="80px;"` → CSS classes (`alt` attribute added).
  - `credit-card-mandate.html.twig`: badge `style="margin:..."` → CSS class.

### Notes
- The mandate badge rule is scoped as `.mollie-credit-card-mandate
  .mollie-mandate-subscription-badge` (two classes) to match the specificity of
  the existing badge rule so the margin override still wins after removing the
  inline style.
- No visual changes intended — same colors and spacing, now token-based.