### PR TITLE
Skip legacy order transaction payment method updates in webhook flow

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -3,7 +3,7 @@
 - Behoben: Die Erfassung beim Versand sendet für Netto-Kunden nun den Bruttobetrag.
 - Behoben: Anreden mit mehr als 20 Zeichen brechen die Zahlungserstellung nicht mehr ab; der Adress-Titel wird nun auf Mollies 20-Zeichen-Limit gekürzt.
 - Behoben: Der automatische Versand beim Wechsel des Lieferstatus läuft nun nur noch für über Mollie bezahlte Bestellungen.
-- Behoben: Das Aktualisieren der Zahlungsart im Webhook-Flow wird nun korrekt für alte Bestellungen übersprungen, statt eines Fehlers wegen fehlender Daten zu werfen.
+- Behoben: Das Aktualisieren der Zahlungsart im Webhook-Flow wird nun korrekt für alte Bestellungen und abgebrochene Bestellungen übersprungen.
 
 # 5.3.0
 - Hinzugefügt: Bestellungen können über einen Mollie-Payment-Link (Route `mollie.pay`) bezahlt werden, nutzbar in E-Mail-Templates, z. B. `{{ rawUrl('mollie.pay', { 'orderId': order.id }, salesChannel.domains|first.url) }}`.

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -3,6 +3,7 @@
 - Behoben: Die Erfassung beim Versand sendet für Netto-Kunden nun den Bruttobetrag.
 - Behoben: Anreden mit mehr als 20 Zeichen brechen die Zahlungserstellung nicht mehr ab; der Adress-Titel wird nun auf Mollies 20-Zeichen-Limit gekürzt.
 - Behoben: Der automatische Versand beim Wechsel des Lieferstatus läuft nun nur noch für über Mollie bezahlte Bestellungen.
+- Behoben: Das Aktualisieren der Zahlungsart im Webhook-Flow wird nun korrekt für alte Bestellungen übersprungen, statt eines Fehlers wegen fehlender Daten zu werfen.
 
 # 5.3.0
 - Hinzugefügt: Bestellungen können über einen Mollie-Payment-Link (Route `mollie.pay`) bezahlt werden, nutzbar in E-Mail-Templates, z. B. `{{ rawUrl('mollie.pay', { 'orderId': order.id }, salesChannel.domains|first.url) }}`.

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -3,7 +3,7 @@
 - Fixed: Shipment capture now sends the gross amount for net-tax customers.
 - Fixed: Salutations longer than 20 characters no longer abort payment creation; the address title is now truncated to Mollie's 20 character limit.
 - Fixed: Automatic shipment on delivery state change now only runs for orders paid via Mollie.
-- Fixed: Updating the payment method in the webhook flow is now correctly skipped for legacy orders instead of throwing an error due to missing data.
+- Fixed: Updating the payment method in the webhook flow is now correctly skipped for legacy orders and cancelled orders.
 
 # 5.3.0
 - Added: Orders can be paid via a Mollie payment link (route `mollie.pay`), which can be used in email templates, e.g. `{{ rawUrl('mollie.pay', { 'orderId': order.id }, salesChannel.domains|first.url) }}`.

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -3,6 +3,7 @@
 - Fixed: Shipment capture now sends the gross amount for net-tax customers.
 - Fixed: Salutations longer than 20 characters no longer abort payment creation; the address title is now truncated to Mollie's 20 character limit.
 - Fixed: Automatic shipment on delivery state change now only runs for orders paid via Mollie.
+- Fixed: Updating the payment method in the webhook flow is now correctly skipped for legacy orders instead of throwing an error due to missing data.
 
 # 5.3.0
 - Added: Orders can be paid via a Mollie payment link (route `mollie.pay`), which can be used in email templates, e.g. `{{ rawUrl('mollie.pay', { 'orderId': order.id }, salesChannel.domains|first.url) }}`.

--- a/shopware/Component/Payment/Route/WebhookException.php
+++ b/shopware/Component/Payment/Route/WebhookException.php
@@ -12,7 +12,6 @@ final class WebhookException extends HttpException
     public const TRANSACTION_WITHOUT_PAYMENT_METHOD = 'TRANSACTION_WITHOUT_PAYMENT_METHOD';
     public const TRANSACTION_WITHOUT_MOLLIE_PAYMENT = 'TRANSACTION_WITHOUT_MOLLIE_PAYMENT';
     public const NEW_PAYMENT_METHOD_NOT_FOUND = 'NEW_PAYMENT_METHOD_NOT_FOUND';
-    public const PAYMENT_WITHOUT_METHOD = 'PAYMENT_WITHOUT_METHOD';
     public const ORDER_WITHOUT_STATE = 'ORDER_WITHOUT_STATE';
     public const PAYMENT_STATUS_CHANGE_FAILED = 'PAYMENT_STATUS_CHANGE_FAILED';
     public const ORDER_STATUS_CHANGE_FAILED = 'ORDER_STATUS_CHANGE_FAILED';
@@ -47,18 +46,6 @@ final class WebhookException extends HttpException
             self::TRANSACTION_WITHOUT_MOLLIE_PAYMENT,
             'Transaction {{transactionId}} does not have mollie custom fields',[
                 'transactionId' => $transactionId,
-            ]
-        );
-    }
-
-    public static function paymentWithoutMethod(string $transactionId, string $paymentId): self
-    {
-        return new self(
-            Response::HTTP_BAD_REQUEST,
-            self::PAYMENT_WITHOUT_METHOD,
-            'Mollie payment {{paymentId}} is without payment method in transaction {{transactionId}}',[
-                'transactionId' => $transactionId,
-                'paymentId' => $paymentId,
             ]
         );
     }

--- a/shopware/Component/Payment/Route/WebhookRoute.php
+++ b/shopware/Component/Payment/Route/WebhookRoute.php
@@ -156,19 +156,15 @@ final class WebhookRoute extends AbstractWebhookRoute
 
     private function updatePaymentMethod(Payment $payment, string $orderNumber, string $salesChannelId, Context $context): void
     {
+        $molliePaymentMethod = $payment->getMethod();
+        if ($molliePaymentMethod === null) {
+            // Legacy transactions or cancelled transactions may not have a Mollie payment method, so we skip the update in that case.
+            return;
+        }
+
         $transaction = $payment->getShopwareTransaction();
         $transactionId = $transaction->getId();
         $transactionPaymentMethod = $transaction->getPaymentMethod();
-
-        $molliePaymentMethod = $payment->getMethod();
-        if ($molliePaymentMethod === null) {
-            // Only throw an exception for new transactions, legacy transactions which include a orderId, but no method should be skipped.
-            if ($payment->getOrderId()) {
-                return;
-            }
-
-            throw WebhookException::paymentWithoutMethod($transactionId, $payment->getId());
-        }
         if ($transactionPaymentMethod === null) {
             throw WebhookException::transactionWithoutPaymentMethod($transactionId);
         }

--- a/shopware/Component/Payment/Route/WebhookRoute.php
+++ b/shopware/Component/Payment/Route/WebhookRoute.php
@@ -162,6 +162,11 @@ final class WebhookRoute extends AbstractWebhookRoute
 
         $molliePaymentMethod = $payment->getMethod();
         if ($molliePaymentMethod === null) {
+            // Only throw an exception for new transactions, legacy transactions which include a orderId, but no method should be skipped.
+            if ($payment->getOrderId()) {
+                return;
+            }
+
             throw WebhookException::paymentWithoutMethod($transactionId, $payment->getId());
         }
         if ($transactionPaymentMethod === null) {

--- a/tests/Unit/Payment/Route/WebhookRouteTest.php
+++ b/tests/Unit/Payment/Route/WebhookRouteTest.php
@@ -129,22 +129,6 @@ final class WebhookRouteTest extends TestCase
         }
     }
 
-    public function testPaymentWithoutMethodThrowsWebhookException(): void
-    {
-        $transactionService = new FakeTransactionService();
-        $transactionService->createValidStruct();
-
-        $fakeClient = new FakeClient('mollieTestId', 'paid', null);
-        $webhookRoute = $this->getRoute($transactionService, $fakeClient);
-
-        try {
-            $webhookRoute->notify('test', $this->context);
-            $this->fail('Expected WebhookException was not thrown');
-        } catch (WebhookException $exception) {
-            $this->assertSame(WebhookException::PAYMENT_WITHOUT_METHOD, $exception->getErrorCode());
-        }
-    }
-
     public function testTransactionWithoutPaymentMethodThrowsWebhookException(): void
     {
         $transactionService = new FakeTransactionService();


### PR DESCRIPTION
- Right now the `notify` function of the `WebhookRoute` which e.g. runs in the scheduled task every minute fails, because there are could be still legacy orders in the system, which do not have the `method` field set in their custom fields
- The payment method update should then be skipped for this legacy order transactions

**Edit**: Cancelled transactions also have to mollie payment method set in the custom fields, we should also skip this transactions instead of throwing an exception. I updated the PR with this change