### PR TITLE
NTR: frontend cleanup - JS files

### DIFF
--- a/src/Resources/app/storefront/src/mollie-payments/helper/device-detection.helper.js
+++ b/src/Resources/app/storefront/src/mollie-payments/helper/device-detection.helper.js
@@ -19,14 +19,6 @@ export default class DeviceDetectionHelper {
     }
 
     /**
-     * Returns if we're dealing with a native Windows browser
-     * @returns {boolean}
-     */
-    static isNativeWindowsBrowser() {
-        return DeviceDetectionHelper.isIEBrowser() || DeviceDetectionHelper.isEdgeBrowser();
-    }
-
-    /**
      * Returns whether the current userAgent is an iPhone device
      * @returns {boolean}
      */
@@ -42,39 +34,5 @@ export default class DeviceDetectionHelper {
     static isIPadDevice() {
         const userAgent = navigator.userAgent;
         return !!userAgent.match(/iPad/i);
-    }
-
-    /**
-     * Returns if we're dealing with the Internet Explorer.
-     * @returns {boolean}
-     */
-    static isIEBrowser() {
-        const userAgent = navigator.userAgent.toLowerCase();
-        return userAgent.indexOf('msie') !== -1 || !!navigator.userAgent.match(/Trident.*rv:\d+\./);
-    }
-
-    /**
-     * Returns if we're dealing with the Windows Edge browser.
-     * @returns {boolean}
-     */
-    static isEdgeBrowser() {
-        const userAgent = navigator.userAgent;
-        return !!userAgent.match(/Edge\/\d+/i);
-    }
-
-    /**
-     * Returns a list of css classes with the boolean result of all device detection functions.
-     * @returns {object}
-     */
-    static getList() {
-        return {
-            'is-touch': DeviceDetectionHelper.isTouchDevice(),
-            'is-ios': DeviceDetectionHelper.isIOSDevice(),
-            'is-native-windows': DeviceDetectionHelper.isNativeWindowsBrowser(),
-            'is-iphone': DeviceDetectionHelper.isIPhoneDevice(),
-            'is-ipad': DeviceDetectionHelper.isIPadDevice(),
-            'is-ie': DeviceDetectionHelper.isIEBrowser(),
-            'is-edge': DeviceDetectionHelper.isEdgeBrowser(),
-        };
     }
 }

--- a/src/Resources/app/storefront/src/mollie-payments/plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugin.js
@@ -4,8 +4,37 @@ export default class Plugin {
     constructor(el, options = {}, pluginName = 'Plugin') {
         this.el = el;
         this._pluginName = pluginName;
+        this._listeners = [];
         this.options = this._mergeOptions(options);
         this.init();
+    }
+
+    /**
+     * Registers a DOM event listener and remembers it so destroy() can remove it.
+     * Prefer this over target.addEventListener() so listeners are cleaned up when
+     * the plugin is torn down or re-initialized (e.g. after an off-canvas cart
+     * reload), which avoids duplicate bindings and memory leaks.
+     * @param {EventTarget} target
+     * @param {string} type
+     * @param {function} handler
+     * @param {boolean|object} options - passed to add/removeEventListener
+     */
+    _addListener(target, type, handler, options = false) {
+        if (!target || typeof target.addEventListener !== 'function') {
+            return;
+        }
+        target.addEventListener(type, handler, options);
+        this._listeners.push({ target, type, handler, options });
+    }
+
+    /**
+     * Removes every listener registered through _addListener().
+     */
+    destroy() {
+        this._listeners.forEach(function (listener) {
+            listener.target.removeEventListener(listener.type, listener.handler, listener.options);
+        });
+        this._listeners = [];
     }
 
     _mergeOptions(options) {

--- a/src/Resources/app/storefront/src/mollie-payments/plugins/creditcard-components.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/creditcard-components.plugin.js
@@ -1,5 +1,4 @@
 import MollieCreditCardMandate from '../core/creditcard-mandate.plugin';
-import DeviceDetectionHelper from '../helper/device-detection.helper';
 import CsrfAjaxModeHelper from '../helper/csrf-ajax-mode.helper';
 import ConfirmPageRepository from '../repository/confirm-page-repository';
 
@@ -266,34 +265,9 @@ export default class MollieCreditCardComponents extends MollieCreditCardMandate 
     }
 
     /**
-     * In IE we have to add the TOS checkbox to the form
-     * when starting it from Javascript.
-     * the original TOS is based on form-associations which do not work in IE.
-     * So we just grab the value and pass it as hidden form so that
-     * Shopware will receive it.
-     *
      * @param form
      */
     continueShopwareCheckout(form) {
-        if (DeviceDetectionHelper.isIEBrowser()) {
-            const createInput = function (name, val) {
-                const input = document.createElement('input');
-                input.type = 'checkbox';
-                input.name = name;
-                input.checked = val;
-                input.style.display = 'none';
-
-                return input;
-            };
-
-            const checkTOS = document.getElementById('tos');
-
-            // we might not always have the TOS checkbox (editOrder)
-            // but if we have it, we have to add it again
-            if (checkTOS !== undefined && checkTOS !== null) {
-                form.insertAdjacentElement('beforeend', createInput('tos', checkTOS.checked));
-            }
-        }
         const csrfMode = new CsrfAjaxModeHelper(window.csrf);
         if (!csrfMode.isActive()) {
             form.submit();

--- a/src/Resources/app/storefront/src/mollie-payments/plugins/phone-plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/phone-plugin.js
@@ -19,13 +19,13 @@ export default class MolliePhonePlugin extends Plugin {
 
         const errorMessageElement = document.querySelector(MOLLIE_PHONE_ERROR_MESSAGE_SELECTOR);
 
-        phoneField.addEventListener('focus', (e) => {
+        this._addListener(phoneField, 'focus', (e) => {
             inputFieldWrapper.classList.add(WAS_VALIDATED_CLS);
             e.target.removeAttribute(INVALID_ATTR);
             errorMessageElement.classList.add(DISPLAY_NONE_CLS);
         });
 
-        phoneField.addEventListener('blur', (e) => {
+        this._addListener(phoneField, 'blur', (e) => {
             const form = e.target.form;
             if (form.reportValidity() === false) {
                 e.target.setAttribute(INVALID_ATTR, true);

--- a/src/Resources/app/storefront/src/mollie-payments/plugins/subscribe-button.plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/subscribe-button.plugin.js
@@ -26,7 +26,7 @@ export default class MollieSubscribeButtonPlugin extends Plugin {
 
         // capture phase, so the hidden field exists before Shopware's add-to-cart plugin
         // serializes the form on the bubbling submit event.
-        this._form.addEventListener('submit', this._onSubmit, true);
+        this._addListener(this._form, 'submit', this._onSubmit, true);
     }
 
     _onSubmit(event) {

--- a/src/Resources/app/storefront/src/mollie-payments/repository/buy-box-repository.js
+++ b/src/Resources/app/storefront/src/mollie-payments/repository/buy-box-repository.js
@@ -65,7 +65,7 @@ export default class BuyBoxRepository {
     }
 
     findPayPalExpressButtons() {
-        return this._document.querySelectorAll('.mollie-paypal-button');
+        return this._document.querySelectorAll('.js-mollie-paypal-button');
     }
 
     findClosestPrivacyBox(expressButton) {

--- a/src/Resources/app/storefront/src/mollie-payments/services/express/privacy-notes.service.js
+++ b/src/Resources/app/storefront/src/mollie-payments/services/express/privacy-notes.service.js
@@ -2,6 +2,7 @@ import BuyBoxRepository from '../../repository/buy-box-repository';
 
 const DISPLAY_NONE_CLS = 'd-none';
 const INVALID_CLS = 'is-invalid';
+const OBSERVED_HOOK = 'js-mollie-observed';
 
 export default class PrivacyNotesService {
     constructor(document) {
@@ -15,14 +16,14 @@ export default class PrivacyNotesService {
      * When all express payment buttons are hidden, the privacy note is also hidden to avoid confusion.
      */
     initCheckbox() {
-        const privacyNotes = this._document.querySelectorAll('.mollie-privacy-note:not(.observed)');
+        const privacyNotes = this._document.querySelectorAll(`.mollie-privacy-note:not(.${OBSERVED_HOOK})`);
 
         for (let i = 0; i < privacyNotes.length; i++) {
             const currentNote = privacyNotes[i];
 
             currentNote.classList.remove(DISPLAY_NONE_CLS);
 
-            currentNote.classList.add('observed');
+            currentNote.classList.add(OBSERVED_HOOK);
 
             const buyElement = this._repoBuyBox.findClosestBuyBox(currentNote);
 

--- a/src/Resources/app/storefront/src/mollie-payments/services/http-client.service.js
+++ b/src/Resources/app/storefront/src/mollie-payments/services/http-client.service.js
@@ -46,7 +46,7 @@ export default class HttpClientService {
             const responseType = xhr.getResponseHeader('content-type');
             const body = 'response' in xhr ? xhr.response : xhr.responseText;
 
-            if (responseType.indexOf('application/json') > -1) {
+            if (responseType && responseType.indexOf('application/json') > -1) {
                 callbackSuccess(JSON.parse(body));
             } else {
                 callbackSuccess(body);
@@ -54,7 +54,7 @@ export default class HttpClientService {
         };
 
         xhr.onerror = function () {
-            if (!callbackError || typeof callbackSuccess !== 'function') {
+            if (!callbackError || typeof callbackError !== 'function') {
                 return;
             }
 

--- a/src/Resources/views/mollie/component/paypal-express-button.html.twig
+++ b/src/Resources/views/mollie/component/paypal-express-button.html.twig
@@ -28,12 +28,12 @@
     {% endif %}
 
     <div class="{{ cols }}">
-        <button name="paypal-express" class="mollie-paypal-button mollie-express-button paypal-button-{{ shape }} paypal-theme-{{ theme }}" data-form-action="{{ path('frontend.mollie.paypal-express.start') }}">
+        <button name="paypal-express"
+                class="mollie-paypal-button js-mollie-paypal-button mollie-express-button paypal-button-{{ shape }} paypal-theme-{{ theme }}"
+                data-form-action="{{ path('frontend.mollie.paypal-express.start') }}">
             <img src="{{ image }}" class="mollie-paypal-button-image" alt="PayPal"/>
             <p class="mollie-paypal-button-label">Checkout</p>
-            <div class="loader">
-
-            </div>
+            <div class="loader"></div>
         </button>
     </div>
 {% endblock %}


### PR DESCRIPTION
Small, behavior-preserving cleanups of the storefront JavaScript. No change to the
custom plugin base or the runtime-decoupling strategy.

### Changes

- **http-client: fixed a broken error callback.** `xhr.onerror` checked
  `callbackSuccess` instead of `callbackError`, so the error handler never fired.
  Also guarded `onload` against a missing `content-type` header (`getResponseHeader`
  returns `null`, and `.indexOf()` on it would throw).

- **Plugin base: added listener lifecycle.** Introduced `_addListener()` (tracks each
  registered listener) and `destroy()` (removes them all). `phone-plugin` and
  `subscribe-button` now register through it. Shopware may re-initialize plugins on
  DOM updates (off-canvas cart, bfcache restore); without teardown this leaves
  duplicate listeners and leaks. Behavior is unchanged — the capture flag is passed
  through to both add/removeEventListener.

- **`js-` hook decoupling.** Split styling classes from JS/test hooks (matches the
  project's existing stylelint rule that bans `.js-` classes from styling):
  - `.mollie-paypal-button` (styled) → JS now selects `.js-mollie-paypal-button`;
    the styling class stays on the element.
  - JS-only state marker `observed` → `js-mollie-observed`.

- **Removed dead IE / legacy-Edge detection.** Dropped `isIEBrowser`, `isEdgeBrowser`,
  `isNativeWindowsBrowser` and `getList` from the device-detection helper, plus the
  IE-only TOS-checkbox workaround in the credit-card components (and its now-unused
  import).
  *Why:* IE is end-of-life, and `isEdgeBrowser()` matched the `Edge/` UA token, which
  is **legacy (EdgeHTML) Edge only** — also discontinued. Modern Edge is Chromium and
  sends `Edg/`, so it was never matched by this code and needs none of these
  workarounds. No coverage lost for current browsers.

### Notes / non-changes
- Kept native `querySelector`/`getElementById` instead of Shopware's `DomAccess`:
  the storefront intentionally touches Shopware only via runtime globals
  (`window.PluginManager`, `window.csrf`) and avoids build-time imports from the
  Shopware source tree, to stay decoupled across SW 6.4–6.7.