### PR TITLE
NTR: improve checkout payment form accessibility

### DIFF
--- a/src/Resources/app/storefront/src/mollie-payments/plugins/phone-plugin.js
+++ b/src/Resources/app/storefront/src/mollie-payments/plugins/phone-plugin.js
@@ -6,7 +6,7 @@ const MOLLIE_PHONE_ERROR_MESSAGE_SELECTOR = '.mollie-phone-field [data-form-vali
 
 const DISPLAY_NONE_CLS = 'd-none';
 const WAS_VALIDATED_CLS = 'was-validated';
-const INVALID_ATTR = 'invalid';
+const INVALID_ATTR = 'aria-invalid';
 
 export default class MolliePhonePlugin extends Plugin {
     init() {
@@ -28,7 +28,7 @@ export default class MolliePhonePlugin extends Plugin {
         this._addListener(phoneField, 'blur', (e) => {
             const form = e.target.form;
             if (form.reportValidity() === false) {
-                e.target.setAttribute(INVALID_ATTR, true);
+                e.target.setAttribute(INVALID_ATTR, 'true');
                 errorMessageElement.classList.remove(DISPLAY_NONE_CLS);
             }
             return form.reportValidity();

--- a/src/Resources/views/storefront/component/payment/component/cc-fields.html.twig
+++ b/src/Resources/views/storefront/component/payment/component/cc-fields.html.twig
@@ -77,28 +77,28 @@
                     </div>
                     <div class="block-group">
                         <div class="block">
-                            <label for="cardHolder">{{ "molliePayments.components.creditCard.cardHolderLabel"|trans|striptags }}</label>
-                            <div id="cardHolder" class="input--field mollie"></div>
-                            <div id="cardHolderError" class="error-message"></div>
+                            <label id="cardHolderLabel">{{ "molliePayments.components.creditCard.cardHolderLabel"|trans|striptags }}</label>
+                            <div id="cardHolder" class="input--field mollie" role="group" aria-labelledby="cardHolderLabel"></div>
+                            <div id="cardHolderError" class="error-message" role="alert"></div>
                         </div>
                     </div>
                     <div class="block-group">
                         <div class="block">
-                            <label for="cardNumber">{{ "molliePayments.components.creditCard.cardNumberLabel"|trans|striptags }}</label>
-                            <div id="cardNumber" class="input--field mollie"></div>
-                            <div id="cardNumberError" class="error-message"></div>
+                            <label id="cardNumberLabel">{{ "molliePayments.components.creditCard.cardNumberLabel"|trans|striptags }}</label>
+                            <div id="cardNumber" class="input--field mollie" role="group" aria-labelledby="cardNumberLabel"></div>
+                            <div id="cardNumberError" class="error-message" role="alert"></div>
                         </div>
                     </div>
                     <div class="block-group">
                         <div class="b1 block">
-                            <label for="expiryDate">{{ "molliePayments.components.creditCard.cardExpiryDateLabel"|trans|striptags }}</label>
-                            <div id="expiryDate" class="input--field mollie"></div>
-                            <div id="expiryDateError" class="error-message"></div>
+                            <label id="expiryDateLabel">{{ "molliePayments.components.creditCard.cardExpiryDateLabel"|trans|striptags }}</label>
+                            <div id="expiryDate" class="input--field mollie" role="group" aria-labelledby="expiryDateLabel"></div>
+                            <div id="expiryDateError" class="error-message" role="alert"></div>
                         </div>
                         <div class="b2 block">
-                            <label for="verificationCode">{{ "molliePayments.components.creditCard.cardVerificationCodeLabel"|trans|striptags }}</label>
-                            <div id="verificationCode" class="input--field mollie"></div>
-                            <div id="verificationCodeError" class="error-message"></div>
+                            <label id="verificationCodeLabel">{{ "molliePayments.components.creditCard.cardVerificationCodeLabel"|trans|striptags }}</label>
+                            <div id="verificationCode" class="input--field mollie" role="group" aria-labelledby="verificationCodeLabel"></div>
+                            <div id="verificationCodeError" class="error-message" role="alert"></div>
                         </div>
                     </div>
 

--- a/src/Resources/views/storefront/component/payment/component/phone-fields.html.twig
+++ b/src/Resources/views/storefront/component/payment/component/phone-fields.html.twig
@@ -13,17 +13,20 @@
         <label for="molliePayPhone">{{ "molliePayments.components.phoneField.headLine"|trans|striptags }}:</label>
         <input id="molliePayPhone"
                placeholder="+49123456789"
-               name="molliePayPhone" 
-               form="confirmOrderForm" 
-               type="text"
+               name="molliePayPhone"
+               form="confirmOrderForm"
+               type="tel"
+               inputmode="tel"
+               autocomplete="tel"
                pattern="\+[1-9]\d{1,14}"
                class="form-control"
-               autocomplete="off"
+               aria-errormessage="molliePayPhoneError"
                value="{{ context.customer.activeBillingAddress.phoneNumber }}"
               />
-        <small class="form-text js-validation-message invalid-feedback d-none"
-               data-form-validation-invalid-phone="true" invalid="true">
-
+        <small id="molliePayPhoneError"
+               class="form-text js-validation-message invalid-feedback d-none"
+               data-form-validation-invalid-phone="true"
+               role="alert">
             {{ "molliePayments.components.phoneField.phoneErrorMessage"|trans|striptags }}
         </small>
     </div>


### PR DESCRIPTION
Brings the Mollie phone and credit card payment fields in line with our form conventions (native HTML5 semantics as the first layer, ARIA for state and announcements). Storefront templates + phone plugin only — no logic or API changes.

## Phone field (phone-fields.html.twig)
- `type="text"` → `type="tel"` + `inputmode="tel"` (correct mobile keyboard) and `autocomplete="tel"` (was off, blocked autofill). The submitted value stays a plain string — `type="tel"` does no numeric coercion.
- Removed the non-standard `invalid="true"` attribute. The error element now has an id, `role="alert"` (live announcement when shown), and is linked to the input via `aria-errormessage`, which is exposed once `aria-invalid="true"` is set.
- `pattern` (E.164-style) kept as the HTML5 validation layer.

## Phone plugin (phone-plugin.js)
- Toggles the standard `aria-invalid` attribute (string value) instead of the invented invalid attribute — this is what activates `aria-errormessage` and the `[aria-invalid]` styling hook.

## Credit card fields (cc-fields.html.twig)
- The four `<label for="…">` pointed at `<div>` iframe mount containers, which is ignored by assistive tech. Labels now carry an id, and each mount container references it via `aria-labelledby` and is exposed as `role="group"`.
- The Error containers (populated by Mollie Components) are now `role="alert"` so component-level errors are announced.