### PR TITLE
NTR: fix button theme fallback & harden button types

### DIFF
--- a/src/Resources/views/mollie/component/paypal-express-button.html.twig
+++ b/src/Resources/views/mollie/component/paypal-express-button.html.twig
@@ -17,7 +17,7 @@
         {% set theme = 'black' %}
         {% set image = asset('bundles/molliepayments/static/ppe-white.png', 'asset') %}
     {% else %}
-        {% set themeso  = 'gold' %}
+        {% set theme = 'gold' %}
     {% endif %}
 
 
@@ -29,6 +29,7 @@
 
     <div class="{{ cols }}">
         <button name="paypal-express"
+                type="button"
                 class="mollie-paypal-button js-mollie-paypal-button mollie-express-button paypal-button-{{ shape }} paypal-theme-{{ theme }}"
                 data-form-action="{{ path('frontend.mollie.paypal-express.start') }}">
             <img src="{{ image }}" class="mollie-paypal-button-image" alt="PayPal"/>

--- a/src/Resources/views/storefront/page/account/subscriptions/subscription-item.html.twig
+++ b/src/Resources/views/storefront/page/account/subscriptions/subscription-item.html.twig
@@ -289,7 +289,7 @@
                     {% block page_account_mollie_subscriptions_order_table_toggle_button %}
                         <div class="col-12 subscription-toggle-button-wrapper">
                             <button class="btn btn-light btn-sm subscription-hide-btn collapsed"
-                                    type="submit"
+                                    type="button"
                                     data-toggle="collapse"
                                     data-target="#subscription{{ subscription.id }}"
                                     data-bs-toggle="collapse"


### PR DESCRIPTION
Fix PayPal express button theme fallback and harden button types -> small storefront template fixes, no logic or API changes.

**PayPal express button** `(mollie/component/paypal-express-button.html.twig)`
- Fixed a typo: the default style branch set themeso instead of theme, so when mollie_paypalexpress_style fell through to the default the button rendered with an empty paypal-theme- class instead of the intended gold theme. It now falls back to gold as designed.
- Added type="button" to the express button
It has no explicit type (defaulting to submit) and is rendered inside the buy-widget form, so a click could submit the add-to-cart form if the JS handler hasn't attached yet. type="button" makes the express flow robust regardless of JS timing.

**Subscription details toggle** `(storefront/page/account/subscriptions/subscription-item.html.twig)`
- Changed the collapse toggle button from type="submit" to type="button"; it only drives a Bootstrap collapse and should never submit.