### PR TITLE
NTR: html - set lang attribute fitting to app language

### DIFF
--- a/src/Resources/views/mollie/pos/checkout.html.twig
+++ b/src/Resources/views/mollie/pos/checkout.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ (app.request.locale|default('en'))|split('-')|first }}">
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 </head>


### PR DESCRIPTION
Das nimmt die Request-Locale, fällt bei fehlendem Wert auf en zurück und schneidet den Sprach-Subtag ab (de-DE → de), damit im lang ein sauberer Sprachcode steht, passend zu dem verwendeten Snippet-Set.