### PR TITLE
NTR: harden JSON parsing in storefront HttpClientService

### DIFF
--- a/src/Resources/app/storefront/src/mollie-payments/services/http-client.service.js
+++ b/src/Resources/app/storefront/src/mollie-payments/services/http-client.service.js
@@ -39,17 +39,23 @@ export default class HttpClientService {
         xhr.setRequestHeader('Content-Type', contentType);
 
         xhr.onload = function () {
-            if (!callbackSuccess || typeof callbackSuccess !== 'function') {
-                return;
-            }
-
             const responseType = xhr.getResponseHeader('content-type');
             const body = 'response' in xhr ? xhr.response : xhr.responseText;
 
+            let payload = body;
             if (responseType && responseType.indexOf('application/json') > -1) {
-                callbackSuccess(JSON.parse(body));
-            } else {
-                callbackSuccess(body);
+                try {
+                    payload = JSON.parse(body);
+                } catch (e) {
+                    if (typeof callbackError === 'function') {
+                        callbackError(e);
+                    }
+                    return;
+                }
+            }
+
+            if (typeof callbackSuccess === 'function') {
+                callbackSuccess(payload);
             }
         };
 


### PR DESCRIPTION
Wrap JSON.parse in try/catch so a malformed or empty JSON response body no longer throws an uncaught SyntaxError out of the XHR onload handler (which skipped both callbacks and left calling flows hanging). On parse  failure the error callback is now invoked instead.