### PR TITLE
NTR: replace XHR-based storefront HttpClientService with fetch

### DIFF
--- a/src/Resources/app/storefront/src/mollie-payments/services/http-client.service.js
+++ b/src/Resources/app/storefront/src/mollie-payments/services/http-client.service.js
@@ -9,7 +9,7 @@ export default class HttpClientService {
      * @param {string} contentType
      */
     get(url, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE) {
-        this.send('GET', url, null, callbackSuccess, callbackError, contentType);
+        return this.send('GET', url, null, callbackSuccess, callbackError, contentType);
     }
 
     /**
@@ -21,11 +21,13 @@ export default class HttpClientService {
      * @param {string} contentType
      */
     post(url, data = null, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE) {
-        this.send('POST', url, data, callbackSuccess, callbackError, contentType);
+        return this.send('POST', url, data, callbackSuccess, callbackError, contentType);
     }
 
     /**
-     * Sends an XMLHttpRequest
+     * Sends the request. JSON responses are parsed, everything else is passed
+     * through as text. A network failure or a malformed JSON body rejects and
+     * therefore lands in callbackError.
      * @param {string} type
      * @param {string} url
      * @param {*} data
@@ -34,39 +36,25 @@ export default class HttpClientService {
      * @param {string} contentType
      */
     send(type, url, data = null, callbackSuccess = null, callbackError = null, contentType = DEFAULT_CONTENT_TYPE) {
-        const xhr = new XMLHttpRequest();
-        xhr.open(type, url);
-        xhr.setRequestHeader('Content-Type', contentType);
-
-        xhr.onload = function () {
-            const responseType = xhr.getResponseHeader('content-type');
-            const body = 'response' in xhr ? xhr.response : xhr.responseText;
-
-            let payload = body;
-            if (responseType && responseType.indexOf('application/json') > -1) {
-                try {
-                    payload = JSON.parse(body);
-                } catch (e) {
-                    if (typeof callbackError === 'function') {
-                        callbackError(e);
-                    }
-                    return;
+        return fetch(url, {
+            method: type,
+            headers: { 'Content-Type': contentType },
+            body: data,
+        })
+            .then((response) =>
+                (response.headers.get('content-type') || '').includes('application/json')
+                    ? response.json()
+                    : response.text(),
+            )
+            .then((payload) => {
+                if (typeof callbackSuccess === 'function') {
+                    callbackSuccess(payload);
                 }
-            }
-
-            if (typeof callbackSuccess === 'function') {
-                callbackSuccess(payload);
-            }
-        };
-
-        xhr.onerror = function () {
-            if (!callbackError || typeof callbackError !== 'function') {
-                return;
-            }
-
-            callbackError();
-        };
-
-        xhr.send(data);
+            })
+            .catch((error) => {
+                if (typeof callbackError === 'function') {
+                    callbackError(error);
+                }
+            });
     }
 }

--- a/src/Resources/app/storefront/tests/service/http-client.spec.js
+++ b/src/Resources/app/storefront/tests/service/http-client.spec.js
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import HttpClientService from '../../src/mollie-payments/services/http-client.service';
+
+const client = new HttpClientService();
+
+/**
+ * Builds a minimal Response stand-in. Only the parts the service touches are
+ * implemented: the content-type header and the json()/text() body readers.
+ */
+function fakeResponse(contentType, body) {
+    return {
+        headers: { get: () => contentType },
+        json: () => (typeof body === 'string' ? Promise.reject(new SyntaxError('invalid json')) : Promise.resolve(body)),
+        text: () => Promise.resolve(String(body)),
+    };
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('HttpClientService', () => {
+    test('parses a json response', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeResponse('application/json', { token: 'abc' })));
+
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        await client.get('/mollie/test', onSuccess, onError);
+
+        expect(onSuccess).toHaveBeenCalledWith({ token: 'abc' });
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    test('passes a non-json response through as text', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeResponse('text/html', '<html></html>')));
+
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        await client.get('/mollie/test', onSuccess, onError);
+
+        expect(onSuccess).toHaveBeenCalledWith('<html></html>');
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    // Regression: a malformed json body used to throw out of the XHR onload
+    // handler, so neither callback ran and the calling flow hung.
+    test('reports a malformed json body to the error callback', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeResponse('application/json', 'not json')));
+
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        await client.post('/mollie/test', null, onSuccess, onError);
+
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalled();
+    });
+
+    test('reports a network failure to the error callback', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('network down')));
+
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        await client.post('/mollie/test', null, onSuccess, onError);
+
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
HttpClientService hand-rolled what the platform already provides: content-type sniffing, JSON parsing, and success/error dispatch over raw XMLHttpRequest. This swaps the internals for fetch and keeps the get/post/send facade, so no call site changes. 72 → 56 lines.

## Why
Deletes reinvented stdlib. The removed code is the part most likely to hide bugs — sniffing headers and parsing bodies by hand.
Fixes a real hang. JSON.parse sat unguarded inside onload. A malformed or empty JSON body threw a SyntaxError that escaped the handler, so neither callback ran and the calling flow stalled silently. With fetch, response.json() rejects and the rejection reaches callbackError — callers always get an answer.
Zero caller churn. The facade is unchanged, so all five call sites (mandate save/delete, POS terminal, Apple Pay session) are untouched. Small diff, small blast radius.
Promise-based, so it composes. Future callers can await or chain instead of nesting callbacks, without touching the service again.

## Why not Shopware's core HttpClient
The plugin deliberately keeps its storefront JS decoupled from Shopware core internals — it ships its own Plugin base class and registers/initialises its plugins itself, because the core's global init sweep breaks on unresolved async plugins in 6.6.x (see the comments in register.js). Importing the core HttpClient would reintroduce exactly the coupling that setup exists to avoid, and tie us to a core API across the supported range (>=6.5.8 <6.8). fetch is native, has no version surface, adds nothing to the bundle, and is available in every browser those Shopware versions support — so it removes custom code without taking on a core dependency.